### PR TITLE
chore(helm): Increase timeout for loki chart

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -6,7 +6,8 @@ metadata:
   name: loki
   namespace: monitoring
 spec:
-  interval: 15m
+  interval: 30m
+  timeout: 15m
   chart:
     spec:
       chart: loki


### PR DESCRIPTION
# Problem
Loki takes a while to restart and chart install times out during flux reconcile.

# Solution
Update timeout to 15m.