### PR TITLE
feat: Add Grafana TV dashboards for homelab monitoring

### DIFF
--- a/kubernetes/apps/monitoring/grafana/dashboards/01-kubernetes.json
+++ b/kubernetes/apps/monitoring/grafana/dashboards/01-kubernetes.json
@@ -1,0 +1,300 @@
+{
+  "title": "Kubernetes Cluster",
+  "uid": "tv-kubernetes",
+  "tags": ["homelab", "tv", "kubernetes"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Cluster Nodes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "targets": [{
+        "expr": "count(kube_node_info)",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 5, "color": "yellow"},
+              {"value": 7, "color": "green"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Nodes Ready",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "targets": [{
+        "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 5, "color": "yellow"},
+              {"value": 7, "color": "green"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Running Pods",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0},
+      "targets": [{
+        "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 50, "color": "yellow"},
+              {"value": 100, "color": "green"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Failed Pods",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0},
+      "targets": [{
+        "expr": "sum(kube_pod_status_phase{phase=\"Failed\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 1, "color": "yellow"},
+              {"value": 5, "color": "red"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "CPU Usage by Node",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 6},
+      "targets": [{
+        "expr": "(1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))) * 100",
+        "legendFormat": "{{instance}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["last", "mean", "max"],
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Memory Usage by Node",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 6},
+      "targets": [{
+        "expr": "100 - ((node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100)",
+        "legendFormat": "{{instance}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["last", "mean", "max"],
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Pod Count by Phase",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "targets": [
+        {
+          "expr": "sum by (phase) (kube_pod_status_phase)",
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "drawStyle": "line",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/monitoring/grafana/dashboards/02-storage-ceph.json
+++ b/kubernetes/apps/monitoring/grafana/dashboards/02-storage-ceph.json
@@ -1,0 +1,358 @@
+{
+  "title": "Storage & Ceph",
+  "uid": "tv-storage",
+  "tags": ["homelab", "tv", "storage", "ceph"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Ceph Health",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "targets": [{
+        "expr": "ceph_health_status",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 1, "color": "yellow"},
+              {"value": 2, "color": "red"}
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"text": "HEALTHY"},
+                "1": {"text": "WARNING"},
+                "2": {"text": "ERROR"}
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Ceph Capacity",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "targets": [{
+        "expr": "ceph_cluster_total_bytes / 1024 / 1024 / 1024 / 1024",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"}
+            ]
+          },
+          "unit": "decbytes",
+          "decimals": 1
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "Ceph Usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0},
+      "targets": [{
+        "expr": "(ceph_cluster_total_used_bytes / ceph_cluster_total_bytes) * 100",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 70, "color": "yellow"},
+              {"value": 85, "color": "red"}
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "OSDs Total",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0},
+      "targets": [{
+        "expr": "ceph_osd_up + ceph_osd_down",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Ceph I/O - Read",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 6},
+      "targets": [{
+        "expr": "rate(ceph_pool_rd_bytes[5m]) / 1024 / 1024",
+        "legendFormat": "{{name}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "MBs",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Ceph I/O - Write",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 6},
+      "targets": [{
+        "expr": "rate(ceph_pool_wr_bytes[5m]) / 1024 / 1024",
+        "legendFormat": "{{name}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "MBs",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "bargauge",
+      "title": "Node Disk Usage - /var (4 nodes with metrics)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 15},
+      "targets": [{
+        "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=\"/var\",fstype=\"xfs\"} / node_filesystem_size_bytes{mountpoint=\"/var\",fstype=\"xfs\"}) * 100)",
+        "legendFormat": "{{instance}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "minVizWidth": 10,
+        "minVizHeight": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 70, "color": "yellow"},
+              {"value": 85, "color": "red"}
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "OSD Status Over Time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 15},
+      "targets": [
+        {
+          "expr": "ceph_osd_up",
+          "legendFormat": "Up",
+          "refId": "A"
+        },
+        {
+          "expr": "ceph_osd_down",
+          "legendFormat": "Down",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Up"},
+            "properties": [
+              {"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}
+            ]
+          },
+          {
+            "matcher": {"id": "byName", "options": "Down"},
+            "properties": [
+              {"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/monitoring/grafana/dashboards/03-network.json
+++ b/kubernetes/apps/monitoring/grafana/dashboards/03-network.json
@@ -1,0 +1,327 @@
+{
+  "title": "Network",
+  "uid": "tv-network",
+  "tags": ["homelab", "tv", "network"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total RX (6h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "targets": [{
+        "expr": "sum(increase(node_network_receive_bytes_total{device=\"ens19\"}[6h])) / 1024 / 1024 / 1024",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"}
+            ]
+          },
+          "unit": "decgbytes",
+          "decimals": 1
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total TX (6h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "targets": [{
+        "expr": "sum(increase(node_network_transmit_bytes_total{device=\"ens19\"}[6h])) / 1024 / 1024 / 1024",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"}
+            ]
+          },
+          "unit": "decgbytes",
+          "decimals": 1
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Avg RX Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0},
+      "targets": [{
+        "expr": "avg(rate(node_network_receive_bytes_total{device=\"ens19\"}[5m])) * 8 / 1000000",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 500, "color": "yellow"},
+              {"value": 900, "color": "red"}
+            ]
+          },
+          "unit": "Mbits",
+          "decimals": 1
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Avg TX Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0},
+      "targets": [{
+        "expr": "avg(rate(node_network_transmit_bytes_total{device=\"ens19\"}[5m])) * 8 / 1000000",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 500, "color": "yellow"},
+              {"value": 900, "color": "red"}
+            ]
+          },
+          "unit": "Mbits",
+          "decimals": 1
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Network Traffic - Receive (ens19)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 6},
+      "targets": [{
+        "expr": "rate(node_network_receive_bytes_total{device=\"ens19\"}[5m]) * 8 / 1000000",
+        "legendFormat": "{{instance}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["last", "mean", "max"],
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Mbits",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Network Traffic - Transmit (ens19)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 6},
+      "targets": [{
+        "expr": "rate(node_network_transmit_bytes_total{device=\"ens19\"}[5m]) * 8 / 1000000",
+        "legendFormat": "{{instance}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["last", "mean", "max"],
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Mbits",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Packet Rate - Receive",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 15},
+      "targets": [{
+        "expr": "rate(node_network_receive_packets_total{device=\"ens19\"}[5m])",
+        "legendFormat": "{{instance}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Packet Rate - Transmit",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 15},
+      "targets": [{
+        "expr": "rate(node_network_transmit_packets_total{device=\"ens19\"}[5m])",
+        "legendFormat": "{{instance}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/monitoring/grafana/dashboards/04-servers.json
+++ b/kubernetes/apps/monitoring/grafana/dashboards/04-servers.json
@@ -1,0 +1,309 @@
+{
+  "title": "Server Hardware",
+  "uid": "tv-servers",
+  "tags": ["homelab", "tv", "servers", "hardware"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Challenger",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+      "targets": [{
+        "expr": "avg(redfish_chassis_temperature_celsius{job=\"redfish-exporter-challenger\",sensor_id=~\".*CPU.*Temp\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 70, "color": "yellow"},
+              {"value": 85, "color": "red"}
+            ]
+          },
+          "unit": "celsius",
+          "decimals": 0
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Galaxy",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+      "targets": [{
+        "expr": "avg(redfish_chassis_temperature_celsius{job=\"redfish-exporter-galaxy\",sensor_id=~\".*CPU.*Temp\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 70, "color": "yellow"},
+              {"value": 85, "color": "red"}
+            ]
+          },
+          "unit": "celsius",
+          "decimals": 0
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Yamato",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 0},
+      "targets": [{
+        "expr": "avg(redfish_chassis_temperature_celsius{job=\"redfish-exporter-yamato\",sensor_id=~\".*CPU.*Temp\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 70, "color": "yellow"},
+              {"value": 85, "color": "red"}
+            ]
+          },
+          "unit": "celsius",
+          "decimals": 0
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "CPU Temperatures",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 4},
+      "targets": [{
+        "expr": "redfish_chassis_temperature_celsius{sensor_id=~\".*CPU.*Temp\"}",
+        "legendFormat": "{{job}} - {{sensor_id}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["last", "max"],
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 70, "color": "yellow"},
+              {"value": 85, "color": "red"}
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "System Board Exhaust Temperatures",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 4},
+      "targets": [{
+        "expr": "redfish_chassis_temperature_celsius{sensor_id=~\".*SystemBoardExhaustTemp\"}",
+        "legendFormat": "{{job}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["last", "max"],
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 60, "color": "yellow"},
+              {"value": 75, "color": "red"}
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Fan Speeds (%)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 14},
+      "targets": [{
+        "expr": "redfish_chassis_fan_rpm_percentage",
+        "legendFormat": "{{job}} - {{fan_name}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Power Consumption",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 14},
+      "targets": [{
+        "expr": "redfish_chassis_power_average_consumed_watts",
+        "legendFormat": "{{job}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["last", "mean", "max"],
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/monitoring/grafana/dashboards/05-home.json
+++ b/kubernetes/apps/monitoring/grafana/dashboards/05-home.json
@@ -1,0 +1,458 @@
+{
+  "title": "Home Status",
+  "uid": "tv-home",
+  "tags": ["homelab", "tv", "home", "homeassistant"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "gauge",
+      "title": "Indoor Temperature",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 8, "w": 6, "x": 0, "y": 0},
+      "targets": [{
+        "expr": "avg(homeassistant_climate_current_temperature_celsius{entity!=\"climate.thermostat\"}) * 9/5 + 32",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "fahrenheit",
+          "min": 60,
+          "max": 85,
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"},
+              {"value": 66, "color": "green"},
+              {"value": 77, "color": "yellow"},
+              {"value": 82, "color": "red"}
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "🏠 Dean",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "targets": [{
+        "expr": "homeassistant_person_state{entity=\"person.dean\"}",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "semi-dark-blue"},
+              {"value": 1, "color": "green"}
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"text": "AWAY"},
+                "1": {"text": "HOME"}
+              }
+            }
+          ],
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "🔒 Front Door",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 4},
+      "targets": [{
+        "expr": "homeassistant_lock_state{entity=\"lock.assure_touchscreen_deadbolt\"}",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 1, "color": "green"}
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"text": "UNLOCKED"},
+                "1": {"text": "LOCKED"}
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "🚪 Back Door",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "targets": [{
+        "expr": "homeassistant_lock_state{entity=\"lock.assure_touchscreen_deadbolt_2\"}",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 1, "color": "green"}
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"text": "UNLOCKED"},
+                "1": {"text": "LOCKED"}
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "🚗 Volvo Lock",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "targets": [{
+        "expr": "homeassistant_lock_state{entity=\"lock.volvo_xc40_lock\"}",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 1, "color": "green"}
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"text": "UNLOCKED"},
+                "1": {"text": "LOCKED"}
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Home Power Draw",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 4},
+      "targets": [{
+        "expr": "sum(homeassistant_sensor_power_w{friendly_name=~\".*Consumption.*\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 3000, "color": "yellow"},
+              {"value": 5000, "color": "red"}
+            ]
+          },
+          "unit": "watt",
+          "decimals": 0
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Solar Production",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 4},
+      "targets": [{
+        "expr": "sum(homeassistant_sensor_power_w{friendly_name=~\".*Production.*\"})",
+        "refId": "A"
+      }],
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "semi-dark-blue"},
+              {"value": 1000, "color": "green"},
+              {"value": 3000, "color": "yellow"}
+            ]
+          },
+          "unit": "watt",
+          "decimals": 0
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Power Consumption vs Production",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 8},
+      "targets": [
+        {
+          "expr": "sum(homeassistant_sensor_power_w{friendly_name=~\".*Consumption.*\"})",
+          "legendFormat": "Consumption",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(homeassistant_sensor_power_w{friendly_name=~\".*Production.*\"})",
+          "legendFormat": "Production",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "custom": {
+            "lineWidth": 3,
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Consumption"},
+            "properties": [
+              {"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}
+            ]
+          },
+          {
+            "matcher": {"id": "byName", "options": "Production"},
+            "properties": [
+              {"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Climate Temperatures",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 18},
+      "targets": [{
+        "expr": "homeassistant_climate_current_temperature_celsius{entity!=\"climate.thermostat\"} * 9/5 + 32",
+        "legendFormat": "{{friendly_name}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "fahrenheit",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "HVAC Status",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "a3e5bf5e-1ea2-4461-90c7-362806abda1a"
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 18},
+      "targets": [{
+        "expr": "homeassistant_climate_action",
+        "legendFormat": "{{entity}} - {{action}}",
+        "refId": "A"
+      }],
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "drawStyle": "line"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/monitoring/grafana/dashboards/README.md
+++ b/kubernetes/apps/monitoring/grafana/dashboards/README.md
@@ -1,0 +1,183 @@
+# Grafana TV Dashboards
+
+Optimized dashboards for 720p TV display with playlist rotation, managed via Grafana Operator.
+
+## Overview
+
+These dashboards are deployed using the Grafana Operator CRDs (`GrafanaDashboard`) which automatically:
+- Create and manage dashboards in Grafana
+- Handle updates when JSON files change
+- Provide declarative dashboard management via GitOps
+
+## Playlist
+
+**URL (kiosk mode):**
+```
+https://grafana.deangalvin.dev/playlists/play/dff654pz8n8qoc?kiosk
+```
+
+**Rotation:** 45 seconds per dashboard
+
+## Dashboards
+
+### 1. Kubernetes Cluster (`01-kubernetes.json`)
+- **UID:** `tv-kubernetes`
+- **CRD:** `tv-kubernetes`
+- Cluster node count and health (7 nodes)
+- Pod statistics (running, failed, by phase)
+- CPU and memory usage by node
+- Time series graphs with legend tables
+
+### 2. Storage & Ceph (`02-storage-ceph.json`)
+- **UID:** `tv-storage`
+- **CRD:** `tv-storage-ceph`
+- Ceph cluster health and capacity (249 TB)
+- Ceph I/O rates (read/write by pool)
+- OSD status and counts
+- Worker node disk usage (/var XFS mounts)
+
+### 3. Network (`03-network.json`)
+- **UID:** `tv-network`
+- **CRD:** `tv-network`
+- Total RX/TX in last 6h
+- Current average RX/TX rates
+- Per-node network traffic (ens19 physical interfaces)
+- Packet rates (RX/TX)
+
+### 4. Server Hardware (`04-servers.json`)
+- **UID:** `tv-servers`
+- **CRD:** `tv-servers`
+- CPU temperatures (Challenger, Galaxy, Yamato via Redfish)
+- System board exhaust temps
+- Fan speeds (percentage)
+- Power consumption
+
+### 5. Home Status (`05-home.json`)
+- **UID:** `tv-home`
+- **CRD:** `tv-home`
+- Indoor temperature (Fahrenheit gauge)
+- Presence detection (Dean)
+- Door locks (front, back, Volvo)
+- Power consumption vs solar production
+- Climate temperatures and HVAC status
+
+## Architecture
+
+- **7 Kubernetes nodes:**
+  - 4 worker nodes (with node-exporter)
+  - 3 storage nodes (Ceph, no node-exporter needed)
+- **3 physical servers:**
+  - Challenger, Galaxy, Yamato (Dell servers with iDRAC/Redfish)
+- **Ceph cluster:** 249 TB total capacity
+- **Home Assistant:** Temperature, presence, locks, power monitoring
+
+## Deployment
+
+### Grafana Operator (Current)
+
+Dashboards are automatically deployed via Flux when changes are merged:
+
+1. **JSON files** contain the dashboard definitions
+2. **kustomization.yaml** generates ConfigMaps from JSON files
+3. **grafanadashboard.yaml** creates `GrafanaDashboard` CRDs that reference the ConfigMaps
+4. Grafana Operator watches for these CRDs and creates/updates dashboards in Grafana
+
+To update a dashboard:
+1. Edit the corresponding JSON file
+2. Commit and push to the repo
+3. Flux will sync and Grafana Operator will apply changes automatically
+
+### Manual Deployment (Alternative)
+
+If you need to deploy manually:
+
+```bash
+cd kubernetes/apps/monitoring/grafana/dashboards
+kubectl apply -k .
+```
+
+## File Structure
+
+```
+dashboards/
+├── 01-kubernetes.json          # Kubernetes dashboard JSON
+├── 02-storage-ceph.json        # Storage & Ceph dashboard JSON
+├── 03-network.json             # Network dashboard JSON
+├── 04-servers.json             # Server hardware dashboard JSON
+├── 05-home.json                # Home status dashboard JSON
+├── grafanadashboard.yaml       # GrafanaDashboard CRDs
+├── kustomization.yaml          # Kustomize config with ConfigMap generators
+└── README.md                   # This file
+```
+
+## Prometheus Datasource
+
+All dashboards reference datasource UID: `a3e5bf5e-1ea2-4461-90c7-362806abda1a`
+
+If your Prometheus datasource has a different UID, update it in all JSON files:
+
+```bash
+NEW_UID="your-datasource-uid"
+sed -i "s/a3e5bf5e-1ea2-4461-90c7-362806abda1a/$NEW_UID/g" *.json
+```
+
+## Design Notes
+
+✨ **TV Optimized**
+- Designed for 720p displays (1280×720) - no scrolling needed
+- Large fonts for readability from a distance
+- Color-coded thresholds (green/yellow/red)
+- 45-second rotation interval
+
+🎯 **Smart Filtering**
+- Excludes broken sensors (e.g., faulty thermostat)
+- Focuses on physical interfaces only (ens19)
+- Shows only the 4 worker nodes with node-exporter
+
+📊 **Complete Coverage**
+- Kubernetes workloads and infrastructure
+- Ceph storage cluster health
+- Physical server hardware monitoring
+- Home automation integration
+
+## Grafana Operator Benefits
+
+- **Declarative:** Dashboards defined as code in Git
+- **GitOps Ready:** Automatic sync via Flux
+- **Version Control:** Full history of dashboard changes
+- **No Manual Import:** No need to use Grafana UI or API
+- **Consistent State:** Operator ensures dashboards match desired state
+
+## Troubleshooting
+
+### Dashboard Not Appearing
+
+Check the GrafanaDashboard status:
+```bash
+kubectl get grafanadashboard -n monitoring
+kubectl describe grafanadashboard tv-kubernetes -n monitoring
+```
+
+### ConfigMap Issues
+
+Verify ConfigMaps were created:
+```bash
+kubectl get configmap -n monitoring | grep grafana-dashboard
+```
+
+### Operator Logs
+
+Check Grafana Operator logs:
+```bash
+kubectl logs -n monitoring -l app.kubernetes.io/name=grafana-operator
+```
+
+## Version History
+
+- **2026-03-06:** Initial creation with Grafana Operator CRDs
+  - 5-dashboard rotation for TV display
+  - Added Ceph monitoring
+  - Split network into dedicated dashboard
+  - Fixed temperature conversion (F)
+  - Excluded broken climate sensor
+  - Implemented GitOps-friendly deployment via Operator

--- a/kubernetes/apps/monitoring/grafana/dashboards/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/grafana/dashboards/grafanadashboard.yaml
@@ -1,0 +1,70 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: tv-kubernetes
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  configMapRef:
+    name: grafana-dashboard-tv-kubernetes
+    key: 01-kubernetes.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: tv-storage-ceph
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  configMapRef:
+    name: grafana-dashboard-tv-storage-ceph
+    key: 02-storage-ceph.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: tv-network
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  configMapRef:
+    name: grafana-dashboard-tv-network
+    key: 03-network.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: tv-servers
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  configMapRef:
+    name: grafana-dashboard-tv-servers
+    key: 04-servers.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: tv-home
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  configMapRef:
+    name: grafana-dashboard-tv-home
+    key: 05-home.json

--- a/kubernetes/apps/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/monitoring/grafana/dashboards/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - grafanadashboard.yaml
+configMapGenerator:
+  - name: grafana-dashboard-tv-kubernetes
+    files:
+      - 01-kubernetes.json
+  - name: grafana-dashboard-tv-storage-ceph
+    files:
+      - 02-storage-ceph.json
+  - name: grafana-dashboard-tv-network
+    files:
+      - 03-network.json
+  - name: grafana-dashboard-tv-servers
+    files:
+      - 04-servers.json
+  - name: grafana-dashboard-tv-home
+    files:
+      - 05-home.json
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/monitoring/grafana/ks.yaml
+++ b/kubernetes/apps/monitoring/grafana/ks.yaml
@@ -33,3 +33,20 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-grafana-dashboards
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-grafana-instance
+  path: ./kubernetes/apps/monitoring/grafana/dashboards
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m


### PR DESCRIPTION
## Overview

Adds 5 optimized Grafana dashboards for 720p TV rotation, managed via **Grafana Operator** for full GitOps integration.

## Implementation

Uses Grafana Operator CRDs for declarative dashboard management:
- **grafanadashboard.yaml** - Creates `GrafanaDashboard` CRDs that the operator watches
- **kustomization.yaml** - Generates ConfigMaps from JSON dashboard files
- **JSON files** - Dashboard definitions (optimized for TV)
- **GitOps Ready** - Flux automatically syncs changes, no manual Grafana UI work needed

## Dashboards

### 1. **Kubernetes Cluster** (`01-kubernetes.json`)
- Cluster node count and health (7 nodes)
- Pod statistics (running, failed, by phase)
- CPU and memory usage by node
- Time series graphs with legend tables

### 2. **Storage & Ceph** (`02-storage-ceph.json`)
- Ceph cluster health and capacity (249 TB)
- Ceph I/O rates (read/write by pool)
- OSD status and counts
- Worker node disk usage (/var XFS mounts)

### 3. **Network** (`03-network.json`)
- Total RX/TX in last 6h
- Current average RX/TX rates
- Per-node network traffic (ens19 physical interfaces)
- Packet rates (RX/TX)

### 4. **Server Hardware** (`04-servers.json`)
- CPU temperatures (Challenger, Galaxy, Yamato via Redfish)
- System board exhaust temps
- Fan speeds (percentage)
- Power consumption

### 5. **Home Status** (`05-home.json`)
- Indoor temperature (Fahrenheit gauge)
- Presence detection
- Door locks (front, back, Volvo)
- Power consumption vs solar production
- Climate temperatures and HVAC status

## Features

✨ **TV Optimized**
- Designed for 720p displays (1280×720) - no scrolling needed
- Large fonts for readability from a distance
- Color-coded thresholds (green/yellow/red)
- 45-second rotation interval

🎯 **Smart Filtering**
- Excludes broken sensors (e.g., faulty thermostat)
- Focuses on physical interfaces only (ens19)
- Shows only the 4 worker nodes with node-exporter

📊 **Complete Coverage**
- 7 Kubernetes nodes (4 workers + 3 storage/Ceph)
- 3 physical servers with Redfish monitoring
- Ceph storage cluster
- Home Assistant integration

🔄 **GitOps Benefits**
- Declarative dashboard management
- Version controlled in Git
- Automatic sync via Flux
- No manual Grafana API calls needed
- Operator ensures desired state

## Deployment

Playlist is already configured and live:

**URL (kiosk mode):**
```
https://grafana.deangalvin.dev/playlists/play/dff654pz8n8qoc?kiosk
```

## Files

```
kubernetes/apps/monitoring/grafana/dashboards/
├── 01-kubernetes.json          # Kubernetes dashboard JSON
├── 02-storage-ceph.json        # Storage & Ceph dashboard JSON
├── 03-network.json             # Network dashboard JSON
├── 04-servers.json             # Server hardware dashboard JSON
├── 05-home.json                # Home status dashboard JSON
├── grafanadashboard.yaml       # GrafanaDashboard CRDs (5 dashboards)
├── kustomization.yaml          # ConfigMap generator + resources
└── README.md                   # Full documentation
```

## How It Works

1. **JSON files** define the dashboards
2. **kustomization.yaml** generates ConfigMaps from JSON files (one per dashboard)
3. **grafanadashboard.yaml** creates `GrafanaDashboard` CRDs that reference the ConfigMaps
4. **Grafana Operator** watches for `GrafanaDashboard` CRDs and creates/updates dashboards in Grafana
5. **Flux** auto-syncs when changes are merged to main

## Updating Dashboards

To update a dashboard:
1. Edit the corresponding JSON file
2. Commit and push
3. Flux syncs automatically
4. Grafana Operator applies changes

No manual Grafana UI interaction needed! 🎉