### PR TITLE
feat(talos): hand CNI ownership to cilium

### DIFF
--- a/terraform/modules/talos/30_talos.tf
+++ b/terraform/modules/talos/30_talos.tf
@@ -116,9 +116,6 @@ locals {
         }
       }
       network = {
-        # Stops talos reconciling its flannel manifest. The running flannel
-        # daemonset is left alone -- talos never deletes what it created -- so
-        # unmigrated nodes keep working until phase 4 removes it by hand.
         cni = {
           name = "none"
         }

--- a/terraform/modules/talos/30_talos.tf
+++ b/terraform/modules/talos/30_talos.tf
@@ -116,6 +116,12 @@ locals {
         }
       }
       network = {
+        # Stops talos reconciling its flannel manifest. The running flannel
+        # daemonset is left alone -- talos never deletes what it created -- so
+        # unmigrated nodes keep working until phase 4 removes it by hand.
+        cni = {
+          name = "none"
+        }
         podSubnets = [
           var.kubernetes_pod_cidr
         ],


### PR DESCRIPTION
Phase 2 of the Cilium migration. Sets `cluster.network.cni.name: none`.

Talos stops reconciling its flannel manifest. The **running flannel DaemonSet is left alone** — Talos never deletes what it created — so the four nodes still on flannel keep working exactly as they do now. Phase 4 removes it by hand.

### Why now rather than after the remaining host flips

`apply_mode` is `var.cilium ? "reboot" : "auto"`, and `cni.name` lives in `common_patch`, which every node shares. Today only `defiant` is `cilium = true`, so this reboots exactly one already-migrated worker; the other three hosts take the config with `apply_mode = "auto"` and don't reboot at all.

Land this after all four hosts are flipped and the same one-line change reboots **all 7 nodes at once**. This is the cheap window.

### Before applying

Drain `talos-worker-defiant-1` — it is the only node that reboots.

### Risk

Low. Nothing deletes flannel, and nothing changes for unmigrated nodes. Rollback is reverting to `name: flannel`, at which point Talos resumes reconciling the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo