### PR TITLE
feat(cilium): switch to production values

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -36,4 +36,4 @@ spec:
       mode: cluster-pool
       operator:
         clusterPoolIPv4PodCIDRList: ["10.201.0.0/16"]
-    tunnelPort: 8473 # 8472 was flannel's; kept to avoid a disruptive restart
+    tunnelPort: 8473 # non-default, see #2483

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -36,19 +36,4 @@ spec:
       mode: cluster-pool
       operator:
         clusterPoolIPv4PodCIDRList: ["10.201.0.0/16"]
-    tunnelPort: 8473 # flannel owns 8472
-
-    # Migration-only. All four come out in phase 4, once every node is on cilium
-    # and flannel is deleted:
-    #   customConf  -> false    start writing the CNI config everywhere
-    #   restart     -> true     let the operator restart unmanaged pods
-    #   policy      -> default  enforcement becomes real for the first time
-    #   hostLegacy  -> false    no more cross-CNI traffic to route
-    cni:
-      customConf: true
-    operator:
-      unmanagedPodWatcher:
-        restart: false
-    policyEnforcementMode: never
-    bpf:
-      hostLegacyRouting: true
+    tunnelPort: 8473 # 8472 was flannel's; kept to avoid a disruptive restart


### PR DESCRIPTION
Phase 4 of the Cilium migration. All four migration-only values revert to chart defaults, so the diff is a straight deletion.

| value | was | now (chart default) | effect |
|---|---|---|---|
| `cni.customConf` | `true` | `false` | cilium writes the CNI config unconditionally, no longer gated on the node label |
| `operator.unmanagedPodWatcher.restart` | `false` | `true` | operator restarts pods it doesn't manage — a self-heal, now that there should be none |
| `policyEnforcementMode` | `never` | `default` | **policy enforcement becomes real for the first time** |
| `bpf.hostLegacyRouting` | `true` | auto | no cross-CNI traffic left to route through the host stack |

### Merge only after flannel is deleted

Order matters. Confirm first:

```bash
kubectl get pods -A -o wide | grep '10\.200\.'   # must be empty
kubectl get netpol,cnp -A                          # see below
kubectl -n kube-system delete ds kube-flannel
kubectl -n kube-system delete cm kube-flannel-cfg
```

### The one that deserves attention

`policyEnforcementMode: default` is not cosmetic. **Flannel has no policy engine**, so every NetworkPolicy in this cluster has been silently ignored for its entire life. This is the moment they start being enforced. The repo itself defines none — Flux's own are stripped by `$patch: delete` in `bootstrap/kustomization.yaml` and `flux-system/operator/flux.yaml` — but rendered charts can ship their own, which is why the check above is a cluster query rather than a grep.

`default` still means allow-all for any pod no policy selects, so an empty result = no behaviour change.

### Follow-up, deliberately not in this PR

The `CiliumNodeConfig` and the terraform `cilium` flag are now redundant but **must not be removed until this is applied** — dropping the node label while `customConf: true` would stop cilium writing a CNI config. Separate PR once this is confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo