### PR TITLE
feat(cilium): enable kube-proxy replacement

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -37,3 +37,11 @@ spec:
       operator:
         clusterPoolIPv4PodCIDRList: ["10.201.0.0/16"]
     tunnelPort: 8473 # non-default, see #2483
+    kubeProxyReplacement: true
+    k8sServiceHost: localhost # kubeprism
+    k8sServicePort: 7445
+    # Confines socket LB to the host namespace. Without it, service resolution
+    # happens inside the pod netns and traffic silently bypasses the istio
+    # sidecars that istiod injects into every namespace by default.
+    socketLB:
+      hostNamespaceOnly: true

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -40,8 +40,3 @@ spec:
     kubeProxyReplacement: true
     k8sServiceHost: localhost # kubeprism
     k8sServicePort: 7445
-    # Confines socket LB to the host namespace. Without it, service resolution
-    # happens inside the pod netns and traffic silently bypasses the istio
-    # sidecars that istiod injects into every namespace by default.
-    socketLB:
-      hostNamespaceOnly: true


### PR DESCRIPTION
Phase 5, step 1 of 4. Cilium starts handling services in eBPF. **kube-proxy stays running** — it is removed in a follow-up, once this is confirmed working. The two coexist safely; Cilium's eBPF path takes precedence.

```yaml
kubeProxyReplacement: true
k8sServiceHost: localhost   # kubeprism
k8sServicePort: 7445
```

`k8sServiceHost/Port` were deliberately left out in Phase 1 as inert — until now the agent reached the apiserver through the kubernetes ClusterIP that kube-proxy served. With the replacement on, it needs KubePrism directly (enabled by default on Talos, port 7445).

No `socketLB.hostNamespaceOnly` — nothing is meshed. The istio manifests in the repo are not actually deployed. **That setting becomes mandatory the moment a service mesh lands**, in either sidecar or ambient mode, because socket LB otherwise resolves services inside the pod netns and traffic silently bypasses the proxy. Recorded in `docs/cilium-migration-plan.md`.

### Verify after merge

```bash
cilium status          # KubeProxyReplacement: True
```

Then exercise ClusterIP, NodePort (`qbittorrent-torrent` uses 30741) and the `externalTrafficPolicy: Local` services — traefik, jitsi jvb/prosody, qbittorrent. Those are where eBPF and iptables disagree most visibly.

### Remaining Phase 5 steps

2. terraform `cluster.proxy.disabled: true`, drop `cluster.proxy.extraArgs`
3. delete `ds/kube-proxy` + `cm/kube-proxy`, then roll nodes one at a time to clear stale iptables chains
4. kube-prometheus-stack `kubeProxy.enabled: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo