### PR TITLE
feat(talos): disable kube-proxy

### DIFF
--- a/terraform/modules/talos/30_talos.tf
+++ b/terraform/modules/talos/30_talos.tf
@@ -95,9 +95,7 @@ locals {
         }
       }
       proxy = {
-        extraArgs = {
-          "feature-gates" = "EnvFiles=true"
-        }
+        disabled = true
       }
       scheduler = {
         extraArgs = {


### PR DESCRIPTION
Phase 5, step 2 of 4. Sets `cluster.proxy.disabled: true` and drops the now-pointless `extraArgs`.

Same shape as the CNI handover in #2480: Talos stops *managing* kube-proxy, but **the running DaemonSet is untouched** — Talos never deletes what it created. Nothing changes at apply time. Removing it is step 3, by hand.

### Verify #2485 first

This assumes Cilium is already serving traffic. Note `cilium status` will **not** tell you — that reports deployment health, not datapath state. Use the agent:

```bash
# is the replacement actually active?
kubectl -n kube-system exec ds/cilium -- cilium-dbg status | grep -i kubeproxy
# -> KubeProxyReplacement: True

# and is cilium really programming services, rather than kube-proxy still doing the work?
kubectl -n kube-system exec ds/cilium -- cilium-dbg service list | head
```

(`cilium-dbg`, not `cilium` — the in-pod binary was renamed in 1.16. From the workstation, `cilium config view | grep kube-proxy` confirms the Helm value landed, but only the agent knows what is actually programmed.)

Then exercise a ClusterIP, the NodePort (`qbittorrent-torrent`, 30741), and the `externalTrafficPolicy: Local` services — traefik, jitsi jvb/prosody, qbittorrent. If any of those only work because kube-proxy is still there, this is the last comfortable moment to find out.

### Expected plan

No reboots. `apply_mode` went back to `auto` in #2484, so Talos decides — and this is a cluster-level manifest change, which shouldn't require one. If the plan proposes rebooting nodes, stop: that would take all three control planes at once.

### Then step 3

```bash
kubectl -n kube-system delete ds kube-proxy
kubectl -n kube-system delete cm kube-proxy
```

followed by rolling the nodes **one at a time** to clear kube-proxy's stale iptables chains. Talos has no host shell for `iptables-restore`, so a reboot is the practical cleanup — deliberate, one node at a time, etcd healthy between each.

Step 4 is `kubeProxy.enabled: false` in kube-prometheus-stack, or it alerts on scrape failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo