### PR TITLE
chore(monitoring): stop scraping kube-proxy

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -93,8 +93,7 @@ spec:
       enabled: true
       endpoints: *endpoints
     kubeProxy:
-      enabled: true
-      endpoints: *endpoints
+      enabled: false
     kubeEtcd:
       enabled: true
       endpoints: *endpoints


### PR DESCRIPTION
Phase 5, step 4 — deliberately landed **before** step 3's deletion rather than after.

Cilium has been handling services since #2485 and Talos stopped managing kube-proxy in #2486. Once the DaemonSet is deleted the ServiceMonitor has nothing to scrape, so leaving this enabled means a stretch of scrape-failure alerts for a component that is gone on purpose.

Drops the `endpoints` alias with it — irrelevant once disabled. The `&endpoints` anchor stays defined on `kubeControllerManager`, and `kubeScheduler`/`kubeEtcd` still reference it.

### Unrelated pre-existing oddity, not fixed here

Those endpoints are `10.0.51.101`, `10.0.61.101`, `10.0.71.101` — addresses that do not match this cluster's `10.1.21.0/24` nodes, and have not for some time. So `kubeControllerManager`, `kubeScheduler` and `kubeEtcd` are almost certainly not being scraped either. Out of scope for the migration; worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo