### PR TITLE
feat(istio): deploy istiod

### DIFF
--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -26,14 +26,11 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    sidecarInjectorWebhook:
-      enableNamespacesByDefault: true
     meshConfig:
       enableTracing: true
       defaultConfig:
         tracing:
           sampling: 10
-        holdApplicationUntilProxyStarts: true
       defaultProviders:
         tracing:
           - "opentelemetry"
@@ -46,5 +43,3 @@ spec:
               path: "/"
     global:
       logAsJson: true
-      proxy:
-        holdApplicationUntilProxyStarts: true

--- a/kubernetes/apps/istio-system/kustomization.yaml
+++ b/kubernetes/apps/istio-system/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./base/ks.yaml
-  # - ./discovery/ks.yaml
+  - ./discovery/ks.yaml
   # - ./monitoring/ks.yaml
 patches:
   - patch: |-


### PR DESCRIPTION
First step toward replacing Traefik with an Istio Gateway.

Enables istiod, which was already wired up — `dependsOn` istio-base, healthCheck, ServiceMonitor — but commented out of `istio-system/kustomization.yaml`.

Two values removed while enabling it:

- `sidecarInjectorWebhook.enableNamespacesByDefault: true` — would have injected a sidecar into every namespace on the next pod restart. Injection is now opt-in per namespace.
- `holdApplicationUntilProxyStarts` (in `meshConfig.defaultConfig` and `global.proxy`) — makes an app container wait for its sidecar, meaningless with no sidecars.

Kept the OpenTelemetry tracing config; it applies to gateway Envoys too.

istiod runs and manages nothing until a Gateway exists.

### Verify

```bash
kubectl -n istio-system get pods            # istiod running
kubectl get ns -L istio-injection           # nothing labelled
```

A restarted pod in any namespace should still come up single-container.

### Next

Gateway API CRDs plus a Gateway, then ingresses migrate route by route with Traefik still serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo