### PR TITLE
feat(networking): install gateway api crds

### DIFF
--- a/kubernetes/apps/networking/gateway-api/app/kustomization.yaml
+++ b/kubernetes/apps/networking/gateway-api/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml

--- a/kubernetes/apps/networking/gateway-api/ks.yaml
+++ b/kubernetes/apps/networking/gateway-api/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-gateway-api
+  namespace: flux-system
+  labels:
+    setnamespace.flux.home.arpa/disabled: "true"
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/networking/gateway-api/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false

--- a/kubernetes/apps/networking/kustomization.yaml
+++ b/kubernetes/apps/networking/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
+  - ./gateway-api/ks.yaml
   - ./traefik/ks.yaml
   - ./external-dns/ks.yaml
 patches:


### PR DESCRIPTION
Takes ownership of the Gateway API CRDs and puts them in git.

They are currently installed by the Traefik chart, which ships them in its `crds/` directory — so they exist in the cluster but at whatever bundle version that chart pinned, with no way to control it from values. Since Traefik is being replaced, they should not be owned by the release that is going away.

Standard channel, v1.6.1, pulled from the upstream release via a remote kustomize resource, with a renovate comment so the version is tracked.

The Flux Kustomization carries `setnamespace.flux.home.arpa/disabled: "true"` to opt out of the `networking` `targetNamespace` patch — these are cluster-scoped.

### Delete the existing CRDs first

Helm never upgrades or deletes CRDs from `crds/`, so it will not fight this, but it also will not step aside on its own. Safe to delete — there are no Gateway or HTTPRoute resources in the cluster yet:

```bash
kubectl delete crd \
  gatewayclasses.gateway.networking.k8s.io \
  gateways.gateway.networking.k8s.io \
  httproutes.gateway.networking.k8s.io \
  grpcroutes.gateway.networking.k8s.io \
  referencegrants.gateway.networking.k8s.io \
  backendtlspolicies.gateway.networking.k8s.io
```

Leaves `gateways.networking.istio.io` untouched — different API group, owned by istio-base.

### Verify

```bash
kubectl get crd | grep gateway.networking.k8s.io    # 10, flux-owned
kubectl get gatewayclass                            # istio, Accepted=True
```

If the GatewayClass does not go Accepted, check istiod logs for a Gateway API version complaint — it reads the `gateway.networking.k8s.io/bundle-version` annotation and wants a supported range. That would mean pinning to an older bundle than v1.6.1.

### Next

A `Gateway` in `networking`, where the cert-manager TLS secrets already live. It gets its own LB IP from the Cilium pool and runs alongside Traefik, so routes move one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo