### PR TITLE
feat(networking): add istio gateway

### DIFF
--- a/kubernetes/apps/networking/istio-gateway/app/gateway.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/gateway.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: deangalvin-dev
+      protocol: HTTPS
+      port: 443
+      hostname: "deangalvin.dev"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: "${PRODUCTION_TLS}"
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: deangalvin-dev-wildcard
+      protocol: HTTPS
+      port: 443
+      hostname: "*.deangalvin.dev"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: "${PRODUCTION_TLS}"
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: arcolog-com
+      protocol: HTTPS
+      port: 443
+      hostname: "arcolog.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: "${ARCOLOG_COM_PRODUCTION_TLS}"
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: arcolog-com-wildcard
+      protocol: HTTPS
+      port: 443
+      hostname: "*.arcolog.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: "${ARCOLOG_COM_PRODUCTION_TLS}"
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: glimmerlabs-io
+      protocol: HTTPS
+      port: 443
+      hostname: "glimmerlabs.io"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: "${GLIMMERLABS_IO_PRODUCTION_TLS}"
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: glimmerlabs-io-wildcard
+      protocol: HTTPS
+      port: 443
+      hostname: "*.glimmerlabs.io"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: "${GLIMMERLABS_IO_PRODUCTION_TLS}"
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/apps/networking/istio-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gateway.yaml

--- a/kubernetes/apps/networking/istio-gateway/ks.yaml
+++ b/kubernetes/apps/networking/istio-gateway/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-istio-gateway
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-gateway-api
+    - name: cluster-apps-traefik-certificates
+  interval: 1h
+  path: ./kubernetes/apps/networking/istio-gateway/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false

--- a/kubernetes/apps/networking/kustomization.yaml
+++ b/kubernetes/apps/networking/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./gateway-api/ks.yaml
+  - ./istio-gateway/ks.yaml
   - ./traefik/ks.yaml
   - ./external-dns/ks.yaml
 patches:


### PR DESCRIPTION
Stands up the Istio Gateway alongside Traefik. **Nothing routes to it yet** — no HTTPRoutes exist, so this changes no traffic.

Istio creates a Deployment and a `LoadBalancer` Service for the Gateway, so it picks up its own IP from the Cilium pool and runs fully parallel to Traefik. Routes then move one app at a time.

### Listeners

Six, covering the same surface Traefik serves today. Apex and wildcard need separate listeners because Gateway API takes a single `hostname` per listener and `*.example.com` does not match the apex:

| hostname | cert |
|---|---|
| `deangalvin.dev`, `*.deangalvin.dev` | `${PRODUCTION_TLS}` |
| `arcolog.com`, `*.arcolog.com` | `${ARCOLOG_COM_PRODUCTION_TLS}` |
| `glimmerlabs.io`, `*.glimmerlabs.io` | `${GLIMMERLABS_IO_PRODUCTION_TLS}` |

Deployed into `networking`, where cert-manager already puts those secrets — a Gateway reads TLS secrets from its own namespace, so no ReferenceGrant needed.

`allowedRoutes.namespaces.from: All` so HTTPRoutes can attach from the app namespaces where they belong.

HTTPS only, matching Traefik (`ports.web.expose.default: false`). `deangalvin.com` has a cert but no ingress uses it, so it gets no listener.

### Verify

```bash
kubectl -n networking get gateway main          # PROGRAMMED=True
kubectl -n networking get svc main-istio        # gets an IP from the cilium pool
```

Then `curl -k --resolve` against that IP for a hostname — expect a 404 from Envoy, which confirms TLS terminates and the listener matches. No route exists yet, so 404 is the correct answer.

### Known gap for later

The `localonly` middleware becomes an `AuthorizationPolicy` with `remoteIpBlocks`, which needs Envoy to see real client IPs. That means `externalTrafficPolicy: Local` on the gateway Service, which is not set here. Must be sorted **before** any route currently behind `localonly` moves, or the allowlist fails open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo