### PR TITLE
feat(arcolog): add httproute for ghost

### DIFF
--- a/kubernetes/apps/arcolog/ghost/app/httproute.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/httproute.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app.kubernetes.io/instance: ghost
+    app.kubernetes.io/name: ghost
+  name: ghost-public
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - arcolog.com
+    - blog.arcolog.com
+    - www.arcolog.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ghost
+          port: 2368

--- a/kubernetes/apps/arcolog/ghost/app/kustomization.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./ingress-public.yaml
   - ./mysql.yaml
   - ./pvc.yaml


### PR DESCRIPTION
First route on the Istio gateway. **The Ingress stays**, so Traefik keeps serving these hosts — this only makes them *also* reachable through the gateway. Nothing user-facing changes until DNS moves.

Ghost was picked to go first because it is the simplest case in the cluster: no Traefik middleware and an in-cluster backend. The remaining ingresses each add a complication — `kiali`/`unifi` carry `localonly`, `proxmox`/`zwave` add `authelia`, and those four plus `ceph` point at `ExternalName` Services, which need `ServiceEntry` handling in Istio.

Covers all three hostnames the Ingress does, including the `arcolog.com` apex.

The HTTPRoute lives in `arcolog` and attaches to the Gateway in `networking`, which is allowed by the Gateway's `allowedRoutes.namespaces.from: All`. No ReferenceGrant needed — that is only for cross-namespace `backendRefs`, and `ghost` is local.

### Verify

```bash
kubectl -n arcolog get httproute ghost-public   # Accepted=True, ResolvedRefs=True

GW=$(kubectl -n networking get svc main-istio -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
curl -sSI --resolve blog.arcolog.com:443:$GW https://blog.arcolog.com | head -1
```

Expect a 200 from Ghost rather than the 404 the gateway returns with no route attached.

Also a good first look at whether client IPs survive, now that `externalTrafficPolicy: Local` is set:

```bash
kubectl -n networking logs deploy/main-istio | tail -5
```

Real source addresses rather than `10.1.21.x` node IPs. That is the thing the `localonly` allowlist will depend on, so it is worth confirming here — on a route where being wrong costs nothing — before any protected route moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo