### PR TITLE
fix(istio): drop the otel tracing config

### DIFF
--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -26,21 +26,5 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    meshConfig:
-      enableTracing: true
-      defaultConfig:
-        tracing:
-          sampling: 10
-      defaultProviders:
-        tracing:
-          - "opentelemetry"
-      extensionProviders:
-        - name: "opentelemetry"
-          opentelemetry:
-            service: tempo.monitoring.svc.cluster.local
-            port: 4318
-            http:
-              path: "/"
-              timeout: 5s
     global:
       logAsJson: true

--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -41,5 +41,6 @@ spec:
             port: 4318
             http:
               path: "/"
+              timeout: 5s
     global:
       logAsJson: true


### PR DESCRIPTION
The gateway's Envoy never becomes ready — startup probe 503s indefinitely.

```
Error adding/updating listener(s) 0.0.0.0_443:
  uri: "tempo.monitoring.svc.cluster.local/"
  Proto constraint validation failed (OpenTelemetryConfigValidationError.HttpService
  ... caused by HttpUriValidationError.Timeout: value is required)
```

Envoy's `HttpUri` requires `timeout`. Without it the entire LDS update is rejected — `lds updates: 0 successful, 1 rejected` — so no listener programs and the pod fails its startup probe forever. The `:443` in the message is just the listener the tracing config was attached to.

Removes the whole `meshConfig` block rather than adding the missing field. The config was carried over untouched when istiod was enabled in #2492 and had never run, since istiod was never actually deployed. Better to add tracing deliberately later, once there is something meshed to trace.

### Worth knowing for next time

The Gateway's own status stayed entirely green throughout — `Accepted`, `Programmed`, `ResolvedRefs` all True across all six listeners. Istiod considered the config valid and pushed it; only Envoy rejected it. Gateway status tells you the control plane is happy, not that the data plane works.

### Verify

```bash
kubectl -n networking get pods -l gateway.networking.k8s.io/gateway-name=main   # 1/1 Running
kubectl -n networking logs deploy/main-istio -c istio-proxy --tail=5            # no 'NOT ready'
```

istiod hot-reloads meshConfig, but a pod already stuck in the probe-failure loop may need deleting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo