### PR TITLE
feat(ghost): add httproute for glimmerlabs

### DIFF
--- a/kubernetes/apps/ghost/app/httproute.yaml
+++ b/kubernetes/apps/ghost/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app.kubernetes.io/instance: ghost
+    app.kubernetes.io/name: ghost
+  name: ghost-public
+  namespace: ghost
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - glimmerlabs.io
+    - blog.glimmerlabs.io
+    - www.glimmerlabs.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ghost
+          port: 2368

--- a/kubernetes/apps/ghost/kustomization.yaml
+++ b/kubernetes/apps/ghost/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./namespace.yaml
   - ./app/externalsecret.yaml
   - ./app/helmrelease.yaml
+  - ./app/httproute.yaml
   - ./app/ingress-public.yaml
   - ./app/mysql.yaml
   - ./app/pvc.yaml


### PR DESCRIPTION
Same shape as #2496, for the glimmerlabs Ghost. The Ingress stays, so Traefik keeps serving these hosts.

Covers all three hostnames including the `glimmerlabs.io` apex.

Unlike arcolog, this app has no `ks.yaml` — its resources are listed directly in `kustomization.yaml` and applied by `cluster-apps`, with no `targetNamespace` in play. So the HTTPRoute carries an explicit `namespace: ghost`, matching what the Ingress next to it already does.

### Verify

```bash
GW=$(kubectl -n networking get svc main-istio -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
curl -sSI --resolve blog.glimmerlabs.io:443:$GW https://blog.glimmerlabs.io | head -1
```

### Remaining ingresses

`flux-webhook` is the last simple one. After that they all need groundwork first: `kiali`/`unifi` need `localonly` as an AuthorizationPolicy, `proxmox`/`zwave` add authelia forward-auth, and those four plus `ceph` point at `ExternalName` Services which Istio needs a ServiceEntry for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo