### PR TITLE
feat(networking): move the hand-written ingresses onto the gateway

### DIFF
--- a/kubernetes/apps/flux-system/addons/webhooks/github/httproute.yaml
+++ b/kubernetes/apps/flux-system/addons/webhooks/github/httproute.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: flux-webhook
+  namespace: flux-system
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - "flux-webhook.${DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /hook
+      backendRefs:
+        - name: webhook-receiver
+          port: 80

--- a/kubernetes/apps/flux-system/addons/webhooks/github/kustomization.yaml
+++ b/kubernetes/apps/flux-system/addons/webhooks/github/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./secret.sops.yaml
+  - ./httproute.yaml
   - ./ingress.yaml
   - ./receiver.yaml

--- a/kubernetes/apps/networking/istio-gateway/app/authorizationpolicy.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/authorizationpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: localonly
+  name: private-by-default
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io
@@ -20,8 +20,23 @@ spec:
               - 10.0.0.0/8
       to:
         - operation:
-            hosts:
-              - ceph.deangalvin.dev
-              - proxmox.deangalvin.dev
-              - unifi.deangalvin.dev
-              - zwave.deangalvin.dev
+            notHosts:
+              - arcolog.com
+              - blog.arcolog.com
+              - www.arcolog.com
+              - arcolog.deangalvin.dev
+              - auth.deangalvin.dev
+              - authentik.deangalvin.dev
+              - filebrowser.deangalvin.dev
+              - flux-webhook.deangalvin.dev
+              - ghost.deangalvin.dev
+              - glimmerlabs.io
+              - blog.glimmerlabs.io
+              - www.glimmerlabs.io
+              - hass.deangalvin.dev
+              - jellyfin.deangalvin.dev
+              - meet.deangalvin.dev
+              - musichero.deangalvin.dev
+              - overseerr.deangalvin.dev
+              - plex.deangalvin.dev
+              - wizarr.deangalvin.dev

--- a/kubernetes/apps/networking/istio-gateway/app/authorizationpolicy.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/authorizationpolicy.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: localonly
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: main
+  action: DENY
+  rules:
+    - from:
+        - source:
+            notIpBlocks:
+              - 174.44.7.114/32
+              - 192.168.2.0/24
+              - 72.235.227.218/32
+              - 104.136.73.201/32
+              - 10.0.0.0/8
+      to:
+        - operation:
+            hosts:
+              - ceph.deangalvin.dev
+              - proxmox.deangalvin.dev
+              - unifi.deangalvin.dev
+              - zwave.deangalvin.dev

--- a/kubernetes/apps/networking/istio-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./authorizationpolicy.yaml
   - ./configmap.yaml
   - ./gateway.yaml

--- a/kubernetes/apps/networking/traefik/externalservices/ceph.yaml
+++ b/kubernetes/apps/networking/traefik/externalservices/ceph.yaml
@@ -39,6 +39,28 @@ subsets:
         port: 9283
         protocol: TCP
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: &app ceph
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - ceph.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: *app
+          port: 8080
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/kubernetes/apps/networking/traefik/externalservices/proxmox.yaml
+++ b/kubernetes/apps/networking/traefik/externalservices/proxmox.yaml
@@ -7,13 +7,67 @@ metadata:
     app.kubernetes.io/name: *app
     app.kubernetes.io/instance: *app
 spec:
-  type: ExternalName
-  externalName: 10.0.0.107
+  clusterIP: None
   ports:
     - name: https
       port: &port 8006
       protocol: TCP
       targetPort: *port
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: &app proxmox
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+subsets:
+  - addresses:
+      - ip: 10.0.0.107
+    ports:
+      - name: https
+        port: 8006
+        protocol: TCP
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: &app proxmox
+spec:
+  host: proxmox.networking.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: &app proxmox
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - proxmox.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /sso
+      backendRefs:
+        - name: proxmox-sso
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: *app
+          port: 8006
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/kubernetes/apps/networking/traefik/externalservices/unifi.yaml
+++ b/kubernetes/apps/networking/traefik/externalservices/unifi.yaml
@@ -7,13 +7,60 @@ metadata:
     app.kubernetes.io/name: *app
     app.kubernetes.io/instance: *app
 spec:
-  type: ExternalName
-  externalName: 192.168.2.1
+  clusterIP: None
   ports:
     - name: https
       port: &port 443
       protocol: TCP
       targetPort: *port
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: &app unifi
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+subsets:
+  - addresses:
+      - ip: 192.168.2.1
+    ports:
+      - name: https
+        port: 443
+        protocol: TCP
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: &app unifi
+spec:
+  host: unifi.networking.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: &app unifi
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - unifi.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: *app
+          port: 443
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/kubernetes/apps/networking/traefik/externalservices/zwave.yaml
+++ b/kubernetes/apps/networking/traefik/externalservices/zwave.yaml
@@ -7,13 +7,49 @@ metadata:
     app.kubernetes.io/name: *app
     app.kubernetes.io/instance: *app
 spec:
-  type: ExternalName
-  externalName: 10.0.0.101
+  clusterIP: None
   ports:
     - name: http
       port: &port 8091
       protocol: TCP
       targetPort: *port
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: &app zwave
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+subsets:
+  - addresses:
+      - ip: 10.0.0.101
+    ports:
+      - name: http
+        port: 8091
+        protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: &app zwave
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - zwave.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: *app
+          port: 8091
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Covers every ingress in this repo that is written as a file. **All Ingresses stay**, so Traefik keeps serving everything — these hosts just become reachable through the gateway too.

HTTPRoutes for `flux-webhook`, `ceph`, `unifi`, `proxmox` (including `/sso`) and `zwave`, plus a gateway-wide access policy.

### ExternalName → headless + Endpoints

`unifi`, `proxmox` and `zwave` were `ExternalName` Services. Gateway API `backendRef` resolves a Service to **endpoints**, and an `ExternalName` has none — it is only a DNS alias. They are now headless Services with explicit `Endpoints`, the shape `ceph` already used in the same directory.

**This is the one change touching live Traefik routing.** Same target IPs (`192.168.2.1`, `10.0.0.107`, `10.0.0.101`), and Traefik routes to endpoints as happily as to an ExternalName, but confirm those three still work *through Traefik* after merge, not just through the gateway.

### HTTPS backends

`unifi` (443) and `proxmox` (8006) serve TLS with self-signed certs — Traefik handles it with `--serversTransport.insecureSkipVerify=true`. Equivalent is a `DestinationRule` with `tls.mode: SIMPLE` and `insecureSkipVerify: true`, added for both.

### private-by-default

Rather than listing the hosts to restrict, the policy denies non-allowlisted sources to **everything except an explicit public list**. 21 of the cluster's 27 app routes are `localonly`, so the public list is both shorter and the safer default: a new app is LAN-only until someone publishes it, instead of public until someone remembers to restrict it.

DENY rather than ALLOW, deliberately — an ALLOW policy attached to the Gateway applies to *every* request through it, so anything not matching would start being denied.

Uses `ipBlocks` (connection source) not `remoteIpBlocks` (X-Forwarded-For), since `externalTrafficPolicy: Local` means Envoy sees the client directly with no proxy setting XFF. **Verify from both an allowed and a denied IP before DNS moves.**

### ⚠️ authelia is not here

`ceph`, `proxmox` and `zwave` sit behind `localonly` **and** authelia on Traefik. They get the IP restriction here but not the auth layer, so through the gateway they have one fewer control than through Traefik.

Not exposed today — the gateway's LB IP is not port-forwarded and DNS still points at Traefik. **Authelia must land before these cut over.** Excluded because forward-auth means `meshConfig.extensionProviders`, and a bad meshConfig is what took every listener down in #2497.

### Related

#2503 adds the other 27 routes. The public list here already accounts for them, so the two are consistent once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo