### PR TITLE
feat: add httproutes for the remaining apps

### DIFF
--- a/kubernetes/apps/arcolog/ghost/app/httproute-private.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/httproute-private.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app.kubernetes.io/instance: ghost
+    app.kubernetes.io/name: ghost
+  name: ghost
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - arcolog.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ghost
+          port: 2368

--- a/kubernetes/apps/arcolog/ghost/app/kustomization.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute-private.yaml
   - ./httproute.yaml
   - ./ingress-public.yaml
   - ./mysql.yaml

--- a/kubernetes/apps/auth/authelia/app/httproute.yaml
+++ b/kubernetes/apps/auth/authelia/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authelia-dev
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - auth.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: authelia-dev
+          port: 80

--- a/kubernetes/apps/auth/authelia/app/kustomization.yaml
+++ b/kubernetes/apps/auth/authelia/app/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pgcluster.yaml
   - ./objectbucketclaim.yaml

--- a/kubernetes/apps/auth/authentik/app/httproute.yaml
+++ b/kubernetes/apps/auth/authentik/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authentik-server
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - authentik.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: authentik-server
+          port: 80

--- a/kubernetes/apps/auth/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/auth/authentik/app/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pgcluster.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/default/echo-server/app/httproute.yaml
+++ b/kubernetes/apps/default/echo-server/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-server
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - echo.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: echo-server
+          port: 8080

--- a/kubernetes/apps/default/echo-server/app/kustomization.yaml
+++ b/kubernetes/apps/default/echo-server/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/ersatztv/app/httproute.yaml
+++ b/kubernetes/apps/default/ersatztv/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ersatztv
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - tvadmin.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ersatztv
+          port: 8409

--- a/kubernetes/apps/default/ersatztv/app/kustomization.yaml
+++ b/kubernetes/apps/default/ersatztv/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/default/filebrowser/app/httproute.yaml
+++ b/kubernetes/apps/default/filebrowser/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: filebrowser
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - filebrowser.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: filebrowser
+          port: 80

--- a/kubernetes/apps/default/filebrowser/app/kustomization.yaml
+++ b/kubernetes/apps/default/filebrowser/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/hajimari/app/httproute.yaml
+++ b/kubernetes/apps/default/hajimari/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hajimari
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - apps.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: hajimari
+          port: 3000

--- a/kubernetes/apps/default/hajimari/app/kustomization.yaml
+++ b/kubernetes/apps/default/hajimari/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/jellyfin/app/httproute.yaml
+++ b/kubernetes/apps/default/jellyfin/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyfin
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - jellyfin.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: jellyfin
+          port: 8096

--- a/kubernetes/apps/default/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/default/jellyfin/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/default/lidarr/app/httproute.yaml
+++ b/kubernetes/apps/default/lidarr/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: lidarr
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - lidarr.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: lidarr
+          port: 8686

--- a/kubernetes/apps/default/lidarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/lidarr/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/default/musichero/app/httproute.yaml
+++ b/kubernetes/apps/default/musichero/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: musichero
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - musichero.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: musichero
+          port: 3000

--- a/kubernetes/apps/default/musichero/app/kustomization.yaml
+++ b/kubernetes/apps/default/musichero/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/default/overseerr/app/httproute.yaml
+++ b/kubernetes/apps/default/overseerr/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: overseerr
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - overseerr.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: overseerr
+          port: 80

--- a/kubernetes/apps/default/overseerr/app/kustomization.yaml
+++ b/kubernetes/apps/default/overseerr/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/default/plex/app/httproute.yaml
+++ b/kubernetes/apps/default/plex/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: plex
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - plex.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: plex
+          port: 32400

--- a/kubernetes/apps/default/plex/app/kustomization.yaml
+++ b/kubernetes/apps/default/plex/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/default/prowlarr/app/httproute.yaml
+++ b/kubernetes/apps/default/prowlarr/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prowlarr
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - prowlarr.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: prowlarr
+          port: 80

--- a/kubernetes/apps/default/prowlarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/prowlarr/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/default/qbittorrent/app/httproute.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qbittorrent
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - qbittorrent.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: qbittorrent
+          port: 80

--- a/kubernetes/apps/default/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
   - ./externalsecret.yaml
 labels:

--- a/kubernetes/apps/default/radarr/app/httproute.yaml
+++ b/kubernetes/apps/default/radarr/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${instance_name}
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - ${instance_name}.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ${instance_name}
+          port: 80

--- a/kubernetes/apps/default/radarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/radarr/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/default/redisinsight/app/httproute.yaml
+++ b/kubernetes/apps/default/redisinsight/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: redisinsight
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - redisinsight.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: redisinsight
+          port: 5540

--- a/kubernetes/apps/default/redisinsight/app/kustomization.yaml
+++ b/kubernetes/apps/default/redisinsight/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/default/sabnzbd/app/httproute.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sabnzbd
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - sabnzbd.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: sabnzbd
+          port: 80

--- a/kubernetes/apps/default/sabnzbd/app/kustomization.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/default/sonarr/app/httproute.yaml
+++ b/kubernetes/apps/default/sonarr/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${instance_name}
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - ${instance_name}.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ${instance_name}
+          port: 80

--- a/kubernetes/apps/default/sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/sonarr/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/default/wizarr/app/httproute.yaml
+++ b/kubernetes/apps/default/wizarr/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wizarr
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - wizarr.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: wizarr
+          port: 5690

--- a/kubernetes/apps/default/wizarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/wizarr/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/ghost/app/httproute-private.yaml
+++ b/kubernetes/apps/ghost/app/httproute-private.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app.kubernetes.io/instance: ghost
+    app.kubernetes.io/name: ghost
+  name: ghost
+  namespace: ghost
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - ghost.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ghost
+          port: 2368

--- a/kubernetes/apps/ghost/kustomization.yaml
+++ b/kubernetes/apps/ghost/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./namespace.yaml
   - ./app/externalsecret.yaml
   - ./app/helmrelease.yaml
+  - ./app/httproute-private.yaml
   - ./app/httproute.yaml
   - ./app/ingress-public.yaml
   - ./app/mysql.yaml

--- a/kubernetes/apps/home-assistant/home-assistant/app/httproute.yaml
+++ b/kubernetes/apps/home-assistant/home-assistant/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: home-assistant
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - hass.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: home-assistant
+          port: 8123

--- a/kubernetes/apps/home-assistant/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home-assistant/home-assistant/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: default
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./externalsecret.yaml
   - ./pvc.yaml
 labels:

--- a/kubernetes/apps/jitsi/jitsi/app/httproute.yaml
+++ b/kubernetes/apps/jitsi/jitsi/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jitsi-jitsi-meet-web
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - meet.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: jitsi-jitsi-meet-web
+          port: 80

--- a/kubernetes/apps/jitsi/jitsi/app/kustomization.yaml
+++ b/kubernetes/apps/jitsi/jitsi/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/kube-system/external-secrets/stores/onepassword/httproute.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/onepassword/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: connect
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - onepassword-connect.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: onepassword-connect
+          port: 8080

--- a/kubernetes/apps/kube-system/external-secrets/stores/onepassword/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/onepassword/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: kube-system
 resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./clustersecretstore.yaml
 labels:
   - pairs:

--- a/kubernetes/apps/monitoring/grafana/instance/httproute.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - grafana.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: grafana-service
+          port: 3000

--- a/kubernetes/apps/monitoring/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/monitoring/grafana/instance/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ./datasource.yaml
   - ./externalsecret.yaml
   - ./grafana.yaml
+  - ./httproute.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kube-prometheus-stack-prometheus
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - prometheus.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kube-prometheus-stack-prometheus
+          port: 9090
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kube-prometheus-stack-alertmanager
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - alert-manager.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kube-prometheus-stack-alertmanager
+          port: 9093

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
 labels:

--- a/kubernetes/apps/projectionlab/frontend/app/httproute.yaml
+++ b/kubernetes/apps/projectionlab/frontend/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - projectionlab.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frontend
+          port: 80

--- a/kubernetes/apps/projectionlab/frontend/app/kustomization.yaml
+++ b/kubernetes/apps/projectionlab/frontend/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: frontend

--- a/kubernetes/apps/satisfactory/satisfactory/app/httproute.yaml
+++ b/kubernetes/apps/satisfactory/satisfactory/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: satisfactory
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - satisfactory.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: satisfactory
+          port: 7777

--- a/kubernetes/apps/satisfactory/satisfactory/app/kustomization.yaml
+++ b/kubernetes/apps/satisfactory/satisfactory/app/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 namespace: satisfactory
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./pvc.yaml


### PR DESCRIPTION
Every remaining ingress in the cluster, as raw HTTPRoutes next to each app rather than teaching `app-template` to emit them. **All Ingresses stay** — Traefik keeps serving everything, these hosts just become reachable through the gateway too.

27 files, 27 routes across 10 namespaces. `radarr` and `sonarr` use `${instance_name}`, so one file each covers both instances (`radarr`/`radarr-4k`, `sonarr`/`sonarr-4k`).

Backend names and ports come from the live cluster rather than being inferred from HelmRelease values — several hosts do not match their release name (`ersatztv` → `tvadmin`, `hajimari` → `apps`, `echo-server` → `echo`, `home-assistant` → `hass`).

### ⚠️ The allowlist does not cover these yet

**21 of these 27 carry `localonly` on Traefik.** The `AuthorizationPolicy` in #2502 lists only four hosts, so through the gateway these are currently unrestricted.

Not exposed today — the gateway's LB IP is not port-forwarded and DNS points at Traefik — but **the allowlist has to cover them before any cutover.**

Strongly suggest inverting it while doing that. 21 of 27 being private means listing *public* hosts with `notHosts` is both shorter and **fails closed**: a new app is LAN-only until explicitly published, rather than public until someone remembers to add it. The current shape has the opposite default.

Public today: `arcolog`/`ghost` (both), `auth`, `authentik`, `filebrowser`, `jellyfin`, `musichero`, `overseerr`, `plex`, `wizarr`, `hass`, `meet`, `flux-webhook`.

### Not included

- **`openclaw`** (`llm`, `openclaw`, `gpt`) — that namespace is not in this repo. Also two of its ingresses use a named rather than numeric port, so they need the number looked up.
- **authelia** — `hajimari` joins `ceph`/`proxmox`/`zwave` as needing forward-auth. Still blocked on `meshConfig.extensionProviders`.

### Chart bug found while investigating

In `app-template`, the `localonly` middleware annotation is nested *inside* the `if ingress.icon` conditional. An app setting `localonly: true` without an `icon` silently gets no allowlist. Worth auditing whether anything is currently in that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo