### PR TITLE
feat(istio): add authentik as an ext_authz provider

### DIFF
--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -30,8 +30,8 @@ spec:
       extensionProviders:
         - name: authentik
           envoyExtAuthzHttp:
-            service: ak-outpost-authentik-embedded-outpost.auth.svc.cluster.local
-            port: 9000
+            service: authentik-server.auth.svc.cluster.local
+            port: 80
             timeout: 5s
             pathPrefix: /outpost.goauthentik.io/auth/envoy
             includeRequestHeadersInCheck:

--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -26,5 +26,25 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    meshConfig:
+      extensionProviders:
+        - name: authentik
+          envoyExtAuthzHttp:
+            service: ak-outpost-authentik-embedded-outpost.auth.svc.cluster.local
+            port: 9000
+            timeout: 5s
+            pathPrefix: /outpost.goauthentik.io/auth/envoy
+            includeRequestHeadersInCheck:
+              - cookie
+            headersToUpstreamOnAllow:
+              - set-cookie
+              - x-authentik-email
+              - x-authentik-groups
+              - x-authentik-name
+              - x-authentik-uid
+              - x-authentik-username
+            headersToDownstreamOnDeny:
+              - content-type
+              - set-cookie
     global:
       logAsJson: true


### PR DESCRIPTION
First half of replacing the authelia forward-auth middleware with authentik. **Defines the provider only** — Envoy does not build an ext_authz filter until an AuthorizationPolicy references it, so this changes no traffic.

Contract taken from authentik's [Envoy docs](https://docs.goauthentik.io/add-secure-apps/providers/proxy/server_envoy/): the `/outpost.goauthentik.io/auth/envoy` prefix, `cookie` in the check, and the `x-authentik-*` identity headers passed upstream.

**`timeout: 5s` is set deliberately.** `envoyExtAuthzHttp` builds an Envoy `HttpUri`, and a missing `timeout` on one of those is exactly what rejected every listener in #2497.

### Needs doing in authentik first

The service name assumes the **embedded** outpost. Providers, applications and outposts are authentik UI state, not in this repo (same as the existing `ak-outpost-generic-ldap`), so before the policy lands:

1. Create a Proxy Provider in **forward auth (domain level)** mode for `*.deangalvin.dev`
2. Bind an Application to it
3. Assign it to an outpost
4. Confirm the service name: `kubectl -n auth get svc | grep outpost`

If a dedicated outpost is used rather than the embedded one, `service` here changes to match.

### Verify

```bash
kubectl -n networking get pods -l gateway.networking.k8s.io/gateway-name=main
kubectl -n networking logs deploy/main-istio -c istio-proxy --tail=20
```

Gateway still 1/1 and no rejected LDS. A meshConfig change is what broke it last time, so confirm before going further. The provider pointing at a service that does not exist yet is fine — an unused cluster, not a bad listener.

### Next

An `AuthorizationPolicy` with `action: CUSTOM` and `provider.name: authentik`, scoped to `ceph`, `proxmox`, `zwave` and `apps` — the four hosts behind authelia on Traefik today. Then authelia can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo