### PR TITLE
feat(networking): pin the gateway to a stable ip

### DIFF
--- a/kubernetes/apps/networking/istio-gateway/app/gateway.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/gateway.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   gatewayClassName: istio
   infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: "10.1.21.20"
     parametersRef:
       group: ""
       kind: ConfigMap


### PR DESCRIPTION
Gives the gateway a fixed LB IP so the UniFi port-forward has a stable target. Traefik keeps `10.1.21.10` until it is retired, so this changes no traffic.

```yaml
infrastructure:
  annotations:
    lbipam.cilium.io/ips: "10.1.21.20"
```

`spec.infrastructure.annotations` are copied onto the resources Istio generates for the Gateway, including the Service — which is where LB-IPAM reads the annotation. Same mechanism as `parametersRef` next to it, different field because that one patches *spec* and this one only needs an annotation.

### ⚠️ Confirm .20 is free first

LB-IPAM will not evict an existing assignment, so if something already holds `.20` the gateway's Service goes `<pending>` and its routes stop resolving. Nothing depends on them yet, so it is recoverable — but check before merging:

```bash
kubectl get svc -A --field-selector spec.type=LoadBalancer \
  -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IP:.status.loadBalancer.ingress[0].ip
```

If `.20` is taken, or you would rather it kept the IP it already has, it is a one-line change.

### Verify

```bash
kubectl -n networking get svc main-istio
```

Then point the port-forward at `10.1.21.20` when you are ready to cut over. That flip is the actual cutover — DNS is not involved, since external-dns runs with `--force-default-targets` pointing every record at the WAN IP, so the forward is what selects the ingress.

Reverting the cutover is pointing the forward back at `.10`; no git change needed either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo