### PR TITLE
feat(networking): run three gateway replicas

### DIFF
--- a/kubernetes/apps/networking/istio-gateway/app/configmap.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/configmap.yaml
@@ -7,3 +7,6 @@ data:
   service: |
     spec:
       externalTrafficPolicy: Local
+  deployment: |
+    spec:
+      replicas: 3


### PR DESCRIPTION
The gateway runs a single replica by default. With `externalTrafficPolicy: Local`, Cilium only advertises the LB IP from nodes actually running a backend — so one replica means **one node advertising the route**, and losing that node takes ingress down while six healthy nodes sit idle.

```yaml
deployment: |
  spec:
    replicas: 3
```

Same `parametersRef` ConfigMap as the `service` patch, so no new mechanism. The scheduler spreads replicas of a ReplicaSet across nodes by default, so no explicit constraints needed.

### Verify

```bash
kubectl -n networking get pods -l gateway.networking.k8s.io/gateway-name=main -o wide
cilium bgp routes | grep 10.1.21.20
```

Three pods on distinct nodes, and the LB IP advertised from each of those nodes rather than one.

For reference, Traefik runs as a DaemonSet so all 7 nodes advertise today. Three is less coverage but genuinely HA; bump the number if you want closer parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo