### PR TITLE
refactor(istio): set gateway defaults on the gatewayclass

### DIFF
--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -26,5 +26,13 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    gatewayClasses:
+      istio:
+        deployment:
+          spec:
+            replicas: 3
+        service:
+          spec:
+            externalTrafficPolicy: Local
     global:
       logAsJson: true

--- a/kubernetes/apps/networking/istio-gateway/app/configmap.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/configmap.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: main-gateway-parameters
-data:
-  service: |
-    spec:
-      externalTrafficPolicy: Local

--- a/kubernetes/apps/networking/istio-gateway/app/gateway.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/gateway.yaml
@@ -8,10 +8,6 @@ spec:
   infrastructure:
     annotations:
       lbipam.cilium.io/ips: "10.1.21.20"
-    parametersRef:
-      group: ""
-      kind: ConfigMap
-      name: main-gateway-parameters
   listeners:
     - name: deangalvin-dev
       protocol: HTTPS

--- a/kubernetes/apps/networking/istio-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/networking/istio-gateway/app/kustomization.yaml
@@ -4,5 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./authorizationpolicy.yaml
-  - ./configmap.yaml
   - ./gateway.yaml


### PR DESCRIPTION
You were right that hardcoding replicas in a patch ConfigMap was the wrong shape. Istio has a proper place for this.

```yaml
# istiod values
gatewayClasses:
  istio:
    deployment:
      spec:
        replicas: 3
    service:
      spec:
        externalTrafficPolicy: Local
```

Typed chart values on istiod, applying to every Gateway of the `istio` class. The values file documents `parametersRef` as the *per-gateway* alternative, so class-level is the intended home for defaults like these.

That deletes `main-gateway-parameters` entirely — which also removes the configure-a-Service-through-a-ConfigMap thing you flagged on #2495. Only `infrastructure.annotations` stays on the Gateway, for the LB IP pin, which is genuinely per-gateway.

Supersedes #2510.

### Why replicas at all

The gateway had one pod. Istio's chart omits `replicas` when `autoscaling.enabled`, but no HPA exists for auto-deployed gateways — you confirmed only istiod has one — so Kubernetes applied its default of 1 and nothing would ever change it.

That matters because with `externalTrafficPolicy: Local`, Cilium only advertises the LB IP from nodes running a backend. One replica meant **one node advertising**, so losing that node took ingress down with six healthy nodes idle.

Fixed at 3, no autoscaling. For an ingress that is arguably better — stable capacity and a stable set of BGP advertisers, rather than routes appearing and disappearing as pods scale. Add `horizontalPodAutoscaler` to the same block if you ever want burst.

### Verify

```bash
kubectl -n networking get pods -l gateway.networking.k8s.io/gateway-name=main -o wide
kubectl -n networking get svc main-istio -o jsonpath='{.spec.externalTrafficPolicy}{"  "}{.status.loadBalancer.ingress[0].ip}{"\n"}'
cilium bgp routes | grep 10.1.21.20
```

Three pods on distinct nodes, `Local` and `10.1.21.20` still on the Service (proving the class-level service patch took over from the deleted ConfigMap), and `.20` advertised from three nodes.

That middle check is the one that matters — if `externalTrafficPolicy` came back `Cluster`, the class-level patch did not apply and `private-by-default` would start matching node IPs instead of real clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo