### PR TITLE
feat(external-dns): publish records from httproutes

### DIFF
--- a/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
       - name: EXTERNAL_DNS_DEFAULT_TARGETS
         value: "96.234.119.68"
     policy: sync
-    sources: ["ingress", "service"]
+    sources: ["gateway-httproute", "ingress", "service"]
     txtPrefix: k8s.
     txtOwnerId: default
     domainFilters: ["deangalvin.com", "deangalvin.dev", "bananaboydean.com", "bananaboydean.dev", "glimmerlabs.io", "arcolog.com"]


### PR DESCRIPTION
First step of retiring Traefik. Adds `gateway-httproute` alongside the existing sources.

```yaml
sources: ["gateway-httproute", "ingress", "service"]
```

### Why running both is safe

Normally two sources claiming the same hostname would fight. Here they cannot: `--force-default-targets` with `EXTERNAL_DNS_DEFAULT_TARGETS: 96.234.119.68` overrides whatever target a source would supply, so an Ingress-derived and an HTTPRoute-derived record for the same host are **byte-identical**. No conflict, nothing to reconcile.

### Why it has to come first

`policy: sync` means external-dns deletes records whose source disappears. Removing the 38 Ingresses before HTTPRoutes are a source would delete their DNS. With this merged, the records are already backed by HTTPRoutes and the Ingresses can go without a DNS gap.

### Verify

```bash
kubectl -n networking logs deploy/external-dns --tail=40
```

Watch for it listing HTTPRoutes rather than erroring on RBAC — the chart should generate the Gateway API rules from the `sources` list, but that is the thing most likely to be missing. `level=error` mentioning `httproutes.gateway.networking.k8s.io` and `forbidden` would mean the ClusterRole needs the permission added manually.

Records themselves should not change at all, since the targets are identical.

### Then

Remove the 38 Ingresses, then Traefik. Note `networking/traefik/` also holds three things the gateway depends on and which need relocating rather than deleting: `certificates/` (the TLS secrets the listeners reference), `externalservices/` (Services, Endpoints and HTTPRoutes for ceph/unifi/proxmox/zwave), and `proxmox-sso/` (still a backendRef on the proxmox route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo