### PR TITLE
feat(cilium): prepare for istio ambient

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -42,9 +42,6 @@ spec:
     k8sServicePort: 7445
     bgpControlPlane:
       enabled: true
-    # Both required by istio ambient. exclusive lets istio-cni chain itself into
-    # the conflist instead of cilium deleting it; hostNamespaceOnly keeps socket
-    # LB out of the pod netns so ztunnel sees the original destination.
     cni:
       exclusive: false
     socketLB:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -42,3 +42,10 @@ spec:
     k8sServicePort: 7445
     bgpControlPlane:
       enabled: true
+    # Both required by istio ambient. exclusive lets istio-cni chain itself into
+    # the conflist instead of cilium deleting it; hostNamespaceOnly keeps socket
+    # LB out of the pod netns so ztunnel sees the original destination.
+    cni:
+      exclusive: false
+    socketLB:
+      hostNamespaceOnly: true


### PR DESCRIPTION
Cilium prerequisites for ambient, landed **before** istio-cni so the ordering cannot bite. No ambient components yet.

```yaml
cni:
  exclusive: false
socketLB:
  hostNamespaceOnly: true
```

### Why these two, and why first

**`cni.exclusive: false`** — Cilium defaults to deleting other CNI configs from `/etc/cni/net.d`. Ambient depends on `istio-cni` chaining itself in to redirect traffic to ztunnel. Install istio-cni while this is still `true` and Cilium removes its conflist: ambient appears installed and silently does nothing.

**`socketLB.hostNamespaceOnly: true`** — with kube-proxy replacement, socket LB rewrites the destination at `connect()` **inside the pod netns**. ztunnel would then see a backend pod IP instead of the original ClusterIP, so mTLS and L4 policy break with no error. This confines socket LB to the host namespace so the per-packet path keeps the real destination.

This is the setting I added in #2485, removed once we established nothing was meshed, and it now comes back for real. Its failure mode is silence, which is why it is worth landing deliberately rather than alongside ztunnel.

### ⚠️ This one is not inert

`hostNamespaceOnly` is a real datapath change — service resolution for pods moves from `connect()`-time rewriting to the per-packet tc path. Existing traffic should be unaffected, but it is not a no-op the way `cni.exclusive` is.

### Restart required

Per #2497: **a Cilium Helm value change restarts nothing.** `cilium config view` will show both immediately while every agent keeps its old config.

```bash
kubectl -n kube-system rollout restart ds/cilium
kubectl -n kube-system rollout status ds/cilium
```

### Verify

```bash
kubectl -n kube-system exec ds/cilium -- cilium-dbg status | grep -iE "kubeproxy|socket"
kubectl -n kube-system exec ds/cilium -- cilium-dbg service list | head
```

Then exercise the gateway and a couple of apps — this touches how every pod resolves services, so a broken socket LB path would show up as apps failing to reach each other rather than anything gateway-shaped.

`bpf.masquerade` stays off, which ambient also requires — Istio documents enabling it as unsupported because it breaks the link-local health-check addresses. It is unset, so nothing to do.

### Next

`istio-cni` and `ztunnel` charts, then enrol namespaces one at a time with `istio.io/dataplane-mode: ambient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo