### PR TITLE
feat(istio): switch istiod to the ambient profile

### DIFF
--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -26,6 +26,7 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    profile: ambient
     gatewayClasses:
       istio:
         deployment:


### PR DESCRIPTION
Second step toward ambient. **Nothing is meshed by this** — that needs the `cni` and `ztunnel` charts plus a namespace label.

```yaml
profile: ambient
```

Deliberately the profile rather than the individual values, because the **chart ships its own copy** of `profile-ambient.yaml`. That resolves to whatever 1.30.3 expects instead of pinning what upstream main happens to contain today — which matters, since the current upstream profile includes `meshConfig.serviceScopeConfigs`, a field that may not exist in 1.30.

What it sets: `pilot.env.PILOT_ENABLE_AMBIENT: "true"`, `meshConfig.defaultConfig.proxyMetadata.ISTIO_META_ENABLE_HBONE: "true"`, `global.variant: distroless`, and `cni.ambient.enabled` (inert here, it is for the cni chart).

### Why this is separate from cni/ztunnel

It touches `meshConfig`, and a bad meshConfig is what rejected **every** gateway listener in #2497 — istiod happily pushed invalid config and only Envoy refused it, with the Gateway resource still showing green. Landing it alone means if the gateway breaks, there is exactly one cause.

Also note `global.variant: distroless` changes the istiod image.

### Verify

```bash
kubectl -n istio-system get pods
kubectl -n networking get pods -l gateway.networking.k8s.io/gateway-name=main
kubectl -n networking logs deploy/main-istio -c istio-proxy --tail=20
```

istiod healthy, all three gateway pods still `1/1`, and **no `rejected`/`NOT ready` in the proxy logs** — that last one is the check that actually matters, since the Gateway status will look fine either way.

Then load something through the gateway to confirm the data plane still serves.

### Next

`istio-cni` and `ztunnel` charts, then enrol one low-stakes namespace with `istio.io/dataplane-mode: ambient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo