### PR TITLE
feat(istio): deploy istio-cni and ztunnel

### DIFF
--- a/kubernetes/apps/istio-system/cni/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/cni/app/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helmrelease_v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istio-cni
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: cni
+      version: 1.30.3
+      sourceRef:
+        kind: HelmRepository
+        name: istio
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    profile: ambient
+    global:
+      logAsJson: true

--- a/kubernetes/apps/istio-system/cni/app/kustomization.yaml
+++ b/kubernetes/apps/istio-system/cni/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/istio-system/cni/ks.yaml
+++ b/kubernetes/apps/istio-system/cni/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomization_v1beta2.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-istio-cni
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-istio-discovery
+  path: ./kubernetes/apps/istio-system/cni/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: istio-cni
+      namespace: istio-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/apps/istio-system/kustomization.yaml
+++ b/kubernetes/apps/istio-system/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   # Flux-Kustomizations
   - ./base/ks.yaml
   - ./discovery/ks.yaml
+  - ./cni/ks.yaml
+  - ./ztunnel/ks.yaml
   # - ./monitoring/ks.yaml
 patches:
   - patch: |-

--- a/kubernetes/apps/istio-system/ztunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/ztunnel/app/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helmrelease_v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ztunnel
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: ztunnel
+      version: 1.30.3
+      sourceRef:
+        kind: HelmRepository
+        name: istio
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    profile: ambient
+    global:
+      logAsJson: true

--- a/kubernetes/apps/istio-system/ztunnel/app/kustomization.yaml
+++ b/kubernetes/apps/istio-system/ztunnel/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/istio-system/ztunnel/ks.yaml
+++ b/kubernetes/apps/istio-system/ztunnel/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomization_v1beta2.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-ztunnel
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-istio-cni
+  path: ./kubernetes/apps/istio-system/ztunnel/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: ztunnel
+      namespace: istio-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m


### PR DESCRIPTION
The ambient data plane. **Nothing is meshed by this** — pods are only enrolled when a namespace carries `istio.io/dataplane-mode: ambient`, and none do.

Two charts from the existing istio HelmRepository, both at 1.30.3 to match istiod, both on `profile: ambient`:

- **`cni`** — a node agent that sets up in-pod traffic redirection to ztunnel. Not a CNI plugin in the usual sense; it chains itself into the existing conflist rather than replacing Cilium.
- **`ztunnel`** — the per-node L4 proxy. This is the actual mesh: mTLS and L4 authorization between enrolled pods.

Chained via `cluster-apps-istio-discovery` → `cni` → `ztunnel`, since ztunnel needs both a control plane and the redirection agent to be useful.

### Talos paths need no overrides

The chart defaults are `cniBinDir: /opt/cni/bin` and `cniConfDir: /etc/cni/net.d`, which is exactly where Talos keeps them and where Cilium already writes. `chained: true` is also the default, which is what we want — istio-cni adds itself to Cilium's chain rather than displacing it.

This is what #2514 was for: with `cni.exclusive: true` Cilium would delete istio's conflist and ambient would look installed while doing nothing.

### Verify

```bash
kubectl -n istio-system get pods
kubectl -n kube-system exec ds/cilium -- ls /host/etc/cni/net.d
```

istio-cni and ztunnel DaemonSets running on all 7 nodes, and **both** `05-cilium.conflist` and istio's conflist present in `/etc/cni/net.d`. If istio's file is missing or vanishes, `cni.exclusive` did not take effect and the agents need restarting.

Then confirm existing pods still work — istio-cni touches CNI config on every node, so a mistake shows up as new pods failing to get networking. Delete a throwaway pod and check it comes back.

### Next

Enrol one namespace: `kubectl label ns <ns> istio.io/dataplane-mode=ambient`. Start somewhere low-stakes — `default` has the most to lose, so something like `arcolog` or `ghost` is a better first move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo