### PR TITLE
fix(istio): allow privileged pods in istio-system

### DIFF
--- a/kubernetes/apps/istio-system/namespace.yaml
+++ b/kubernetes/apps/istio-system/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: istio-system
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
`istio-cni` cannot start — its DaemonSet is rejected by PodSecurity:

```
pods "istio-cni-node-..." is forbidden: violates PodSecurity "baseline:latest":
forbidden AppArmor profiles, non-default capabilities (NET_ADMIN, NET_RAW,
SYS_ADMIN, SYS_PTRACE), hostPath volumes (cni-bin-dir, cni-net-dir, ...)
```

### It is Talos, not the namespace

The namespace had no PodSecurity labels at all — I checked before writing #2516 and concluded nothing would block it. What I missed is that **Talos ships a default PodSecurity admission config** enforcing `baseline` cluster-wide, exempting only `kube-system`.

That is why Cilium's equally privileged DaemonSet runs happily and this does not: Cilium lives in the exempt namespace.

```yaml
pod-security.kubernetes.io/enforce: privileged
```

A namespace label overrides the cluster default for that namespace only, which is the idiomatic fix and keeps it in git. The alternative — adding `istio-system` to Talos's `admissionControl` exemptions in terraform — would work but is a cluster-wide change for a namespace-scoped need, and it would not be visible next to the workloads that require it.

istio-cni and ztunnel genuinely need this: entering pod network namespaces to install redirect rules requires `NET_ADMIN`, `SYS_ADMIN` and hostPath access to `/opt/cni/bin` and `/etc/cni/net.d`.

### Note on warnings

Talos also sets `audit`/`warn` to `restricted`, which this does not override — so pod creation in `istio-system` will emit restricted-policy warnings. Harmless, and left in place deliberately rather than blanket-silencing a privileged namespace. Add `warn`/`audit` labels if the noise is annoying.

### Verify

```bash
kubectl -n istio-system get pods
kubectl -n kube-system exec ds/cilium -- ls /host/etc/cni/net.d
```

istio-cni and ztunnel running on all 7 nodes, and both `05-cilium.conflist` and an istio conflist present — the check from #2516 that could not run while the DaemonSet was blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo