### PR TITLE
feat(ghost): enrol in the ambient mesh

### DIFF
--- a/kubernetes/apps/ghost/namespace.yaml
+++ b/kubernetes/apps/ghost/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: ghost
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    istio.io/dataplane-mode: ambient


### PR DESCRIPTION
First namespace into the mesh. One label:

```yaml
istio.io/dataplane-mode: ambient
```

Picked `ghost` because it is the smallest real workload with an internal dependency — Ghost talks to `mysql` in the same namespace, so **both ends are meshed** and that hop gets mTLS. It is also one app rather than eighteen, so pod-to-pod breakage would be unmistakable. `default` would have been a poor first choice.

### No pod restarts

istio-cni captures already-running pods by entering their netns, so labelling the namespace meshes what is already there. Nothing restarts, and pods gain **no extra container** — that is the whole point of ambient versus sidecars, and it means unenrolling is just removing the label.

### The gateway keeps working

The gateway lives in `networking`, which is not enrolled. Inbound traffic from a non-meshed source still reaches an ambient workload — ztunnel accepts plaintext unless a `PeerAuthentication` sets `STRICT`, and none exists. So gateway → ghost is unaffected while ghost → mysql becomes mTLS.

Worth knowing so it is not a surprise later: adding `STRICT` `PeerAuthentication` before enrolling `networking` would break that path.

### Verify

```bash
kubectl -n ghost get pods                                    # still 1 container each, no restarts
istioctl ztunnel-config workload --namespace ghost           # pods listed as enrolled
```

Then load `blog.glimmerlabs.io` — that exercises gateway → ghost → mysql, so it covers both the unmeshed inbound hop and the newly meshed internal one.

Ghost failing to reach mysql is the failure mode to watch for; it would show as the site erroring rather than anything ingress-shaped.

### Next

If this holds, enrol further namespaces one at a time. `arcolog` is the natural second (same shape), then the busier ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo