### PR TITLE
fix(ghost): drop the mariadb network policy

### DIFF
--- a/kubernetes/apps/ghost/app/mysql.yaml
+++ b/kubernetes/apps/ghost/app/mysql.yaml
@@ -41,6 +41,8 @@ spec:
     kind: OCIRepository
     name: ghost
   values:
+    networkPolicy:
+      enabled: false
     auth:
       existingSecret: ghost-secret
       username: ghost


### PR DESCRIPTION
Ghost cannot reach mariadb since the ambient enrolment in #2518. Cilium is dropping it outright:

```
xx drop (Policy denied) ... identity 21991->2353: 10.201.0.33:48516 -> 10.201.0.151:15008 tcp SYN
```

The bitnami mariadb chart ships a NetworkPolicy — `ghost-mariadb`, **327 days old**. It allows the service port and denies everything else, so ghost → `3306` was fine and ghost's ztunnel → `15008` (HBONE) is not.

### This is the Phase 4 warning coming due

From `docs/cilium-migration-plan.md`, written before restoring `policyEnforcementMode: default`:

> Flannel has no policy engine, so every NetworkPolicy in this cluster has been silently ignored for its entire life. The flip below is the first moment enforcement becomes real. The repo itself has none — but *rendered charts* can ship their own, so check what is actually in the cluster (`kubectl get netpol,cnp -A`) rather than grepping the repo.

That is exactly this policy: invisible in git, invisible under flannel, activated by Cilium, and harmless right up until ambient needed a second port.

### Why disable rather than allow 15008

The chart's policy defaults to `allowExternal: true`, so it permits `3306` from **any pod in the cluster**. It is not isolating mariadb from anything — the only thing it successfully blocks is the mesh. Extending it with `extraIngress` for `15008` would preserve a restriction that was never providing meaningful isolation, and would need repeating for every meshed workload from a bitnami chart.

If real isolation is wanted for mariadb, that is worth doing deliberately as an `AuthorizationPolicy` once ghost is meshed — ztunnel enforces on identity (`spiffe://cluster.local/ns/ghost/sa/ghost-mariadb`) rather than pod labels, which is strictly better than what this policy offered.

### Verify

```bash
kubectl -n ghost get netpol
curl -s -o /dev/null -w '%{http_code}\n' https://www.glimmerlabs.io
kubectl -n istio-system logs ds/ztunnel --since=2m | grep -i error
```

No policy, a 200, and no more `HBONE port 15008` timeouts.

### Worth doing before enrolling more namespaces

```bash
kubectl get netpol -A
```

Any other chart-shipped policy will hit the same wall the moment its namespace is enrolled. Better to know the list now than rediscover it one namespace at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo