### PR TITLE
fix(ghost): redirect the apex to www

### DIFF
--- a/kubernetes/apps/arcolog/ghost/app/httproute.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/httproute.yaml
@@ -11,7 +11,6 @@ spec:
     - name: main
       namespace: networking
   hostnames:
-    - arcolog.com
     - blog.arcolog.com
     - www.arcolog.com
   rules:
@@ -22,3 +21,23 @@ spec:
       backendRefs:
         - name: ghost
           port: 2368
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app.kubernetes.io/instance: ghost
+    app.kubernetes.io/name: ghost
+  name: ghost-apex
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - arcolog.com
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: www.arcolog.com
+            statusCode: 301

--- a/kubernetes/apps/ghost/app/httproute.yaml
+++ b/kubernetes/apps/ghost/app/httproute.yaml
@@ -12,7 +12,6 @@ spec:
     - name: main
       namespace: networking
   hostnames:
-    - glimmerlabs.io
     - blog.glimmerlabs.io
     - www.glimmerlabs.io
   rules:
@@ -23,3 +22,24 @@ spec:
       backendRefs:
         - name: ghost
           port: 2368
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app.kubernetes.io/instance: ghost
+    app.kubernetes.io/name: ghost
+  name: ghost-apex
+  namespace: ghost
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - glimmerlabs.io
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: www.glimmerlabs.io
+            statusCode: 301


### PR DESCRIPTION
`https://glimmerlabs.io/the-glimmer-team/` 404s while `https://www.glimmerlabs.io/the-glimmer-team/` works — same route, same pod, only the Host header differs. So it is Ghost, not Envoy.

Both Ghost instances are canonical on `www`:

```yaml
url: "https://www.glimmerlabs.io"
url: "https://www.arcolog.com"
```

Ghost does not serve cleanly on a non-canonical host — the homepage may render but paths 404, which is exactly the reported symptom. The expectation is that the proxy canonicalises before Ghost sees it.

So the apex stops pointing at the backend and gets a redirect instead:

```yaml
hostnames: [glimmerlabs.io]
rules:
  - filters:
      - type: RequestRedirect
        requestRedirect:
          hostname: www.glimmerlabs.io
          statusCode: 301
```

Rules cannot match on hostname within one HTTPRoute, so this is a second route per site, in the same file. No hostname overlap — the backend route now serves `blog` and `www` only.

Applied to arcolog too, which has the identical shape and would 404 the same way on `arcolog.com/<path>`.

### Why the apex previously appeared to work

It served the homepage, which Ghost will render on any host. Only pathed requests expose it, so `/` looking fine was misleading — and is why this survived the whole ingress migration unnoticed. Traefik was doing the same thing; nothing regressed, we just started testing paths.

Both apexes are already in `private-by-default`'s public list, so the redirect is reachable externally.

### Verify

```bash
curl -s -o /dev/null -w '%{http_code} -> %{url_effective}\n' -L https://glimmerlabs.io/the-glimmer-team/
curl -s -o /dev/null -w '%{http_code} -> %{url_effective}\n' -L https://arcolog.com/
```

Expect a 301 to the `www` host and a final 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo