### PR TITLE
feat(arcolog): enrol in the ambient mesh

### DIFF
--- a/kubernetes/apps/arcolog/ghost/app/mysql.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/mysql.yaml
@@ -38,6 +38,8 @@ spec:
     kind: OCIRepository
     name: ghost
   values:
+    networkPolicy:
+      enabled: false
     auth:
       existingSecret: ghost-secret
       username: ghost

--- a/kubernetes/apps/arcolog/namespace.yaml
+++ b/kubernetes/apps/arcolog/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: arcolog
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    istio.io/dataplane-mode: ambient


### PR DESCRIPTION
Second namespace in, same shape as ghost (#2518, #2519): ghost and mariadb both mesh, and the chart's network policy comes out because it blocks ztunnel's hbone port.

```
kubectl -n arcolog rollout restart deploy/ghost statefulset/ghost-mariadb
istioctl ztunnel-config workloads | grep arcolog
```
Then load www.arcolog.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efux1wUgHSLTP9TA9WQECo