### PR TITLE
feat(istio): send traces to the otel collector

### DIFF
--- a/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/helmrelease.yaml
@@ -35,5 +35,11 @@ spec:
         service:
           spec:
             externalTrafficPolicy: Local
+    meshConfig:
+      extensionProviders:
+        - name: otel
+          opentelemetry:
+            service: otel-collector-opentelemetry-collector.monitoring.svc.cluster.local
+            port: 4317
     global:
       logAsJson: true

--- a/kubernetes/apps/istio-system/discovery/app/kustomization.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./servicemonitor.yaml
+  - ./telemetry.yaml

--- a/kubernetes/apps/istio-system/discovery/app/telemetry.yaml
+++ b/kubernetes/apps/istio-system/discovery/app/telemetry.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: mesh-default
+spec:
+  tracing:
+    - providers:
+        - name: otel
+      randomSamplingPercentage: 100


### PR DESCRIPTION
Points istiod at the collector from #2524 and turns tracing on mesh-wide.

Sampling is 100% because the only thing emitting spans right now is the gateway, so the volume is ingress requests rather than every hop. Worth turning down once waypoints exist.

**What this does and does not get you:** ztunnel is L4 and emits no spans, and there are no waypoints, so the `main` gateway is the only span source. That means one span per inbound request -- route, upstream, latency, response code -- not a service graph. Service-to-service spans need a waypoint per namespace, and joined-up traces need the apps to propagate `traceparent`, which ghost/plex/jellyfin will not do.

Still useful on its own: it should catch the intermittent glimmerlabs 404, which we could not reproduce by hand.

Verify:
```
kubectl -n monitoring logs deploy/otel-collector-opentelemetry-collector | tail
```
Then Explore -> tempo -> search by service name in Grafana.
