### PR TITLE
feat(mesh): add waypoints to ghost and arcolog

### DIFF
--- a/kubernetes/apps/arcolog/ghost/app/kustomization.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./ingress-public.yaml
   - ./mysql.yaml
   - ./pvc.yaml
+  - ./waypoint.yaml

--- a/kubernetes/apps/arcolog/ghost/app/waypoint.yaml
+++ b/kubernetes/apps/arcolog/ghost/app/waypoint.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE

--- a/kubernetes/apps/arcolog/namespace.yaml
+++ b/kubernetes/apps/arcolog/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint

--- a/kubernetes/apps/ghost/ghost/app/kustomization.yaml
+++ b/kubernetes/apps/ghost/ghost/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./ingress-public.yaml
   - ./mysql.yaml
   - ./pvc.yaml
+  - ./waypoint.yaml

--- a/kubernetes/apps/ghost/ghost/app/waypoint.yaml
+++ b/kubernetes/apps/ghost/ghost/app/waypoint.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE

--- a/kubernetes/apps/ghost/namespace.yaml
+++ b/kubernetes/apps/ghost/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint


### PR DESCRIPTION
Adds a waypoint to the two enrolled namespaces so the mesh gets L7, which is what tracing needs. ztunnel is L4 and does not parse HTTP, so spans can only come from an Envoy -- gateways and waypoints. With these in place the mesh-wide `Telemetry` from #2528 applies to them automatically, no config change.

Each request produces a gateway span and a waypoint span **in the same trace**: the gateway Envoy generates the trace id and sets `traceparent` when it forwards, and the waypoint sees that same request and creates a child span. That gives a trace which shows the gateway accepted the request and the app received it, with latency attributed to each. No app changes needed for this part.

Depends on #2528 being merged for spans to actually flow.

Two things this does not do:

- **mariadb is not traced.** It is MySQL, not HTTP, so a waypoint cannot make spans out of it. It stays L4 through ztunnel with mTLS as before.
- **Calls the app originates will start a new trace.** Envoy propagates headers on a request as it passes through, but ghost does not copy incoming headers onto its own outgoing requests, so anything ghost calls will not inherit the trace. That needs instrumentation in the app.

Each waypoint is an extra Envoy pod and an extra hop each way.

Verify:
```
kubectl -n ghost get gateway waypoint
istioctl -n ghost waypoint status
```
