### PR TITLE
feat(monitoring): add the otel operator and instrument ghost

### DIFF
--- a/kubernetes/apps/ghost/ghost/app/helmrelease.yaml
+++ b/kubernetes/apps/ghost/ghost/app/helmrelease.yaml
@@ -28,7 +28,6 @@ spec:
   values:
     defaultPodOptions:
       annotations:
-        sidecar.istio.io/inject: "false"
         instrumentation.opentelemetry.io/inject-nodejs: monitoring/default
     controllers:
       ghost:

--- a/kubernetes/apps/ghost/ghost/app/helmrelease.yaml
+++ b/kubernetes/apps/ghost/ghost/app/helmrelease.yaml
@@ -26,6 +26,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      annotations:
+        sidecar.istio.io/inject: "false"
+        instrumentation.opentelemetry.io/inject-nodejs: monitoring/default
     controllers:
       ghost:
         containers:

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
   - ./otel-collector/ks.yaml
+  - ./otel-operator/ks.yaml
   - ./redfish-exporter/ks.yaml
   - ./tempo/ks.yaml
   - ./vector/ks.yaml

--- a/kubernetes/apps/monitoring/otel-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/app/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: otel-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: otel-operator
+  interval: 30m
+  maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    manager:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 256Mi

--- a/kubernetes/apps/monitoring/otel-operator/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/monitoring/otel-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: otel-operator
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.120.0
+  url: oci://ghcr.io/open-telemetry/opentelemetry-helm-charts/opentelemetry-operator

--- a/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: default
+spec:
+  exporter:
+    endpoint: http://otel-collector-opentelemetry-collector.monitoring:4318
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_always_on
+  nodejs: {}

--- a/kubernetes/apps/monitoring/otel-operator/config/kustomization.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/config/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./instrumentation.yaml

--- a/kubernetes/apps/monitoring/otel-operator/ks.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/ks.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-otel-operator
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-cert-manager
+  interval: 30m
+  path: ./kubernetes/apps/monitoring/otel-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: otel-operator
+      namespace: monitoring
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-otel-operator-config
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-otel-operator
+  interval: 30m
+  path: ./kubernetes/apps/monitoring/otel-operator/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Adds the OpenTelemetry Operator for its auto-instrumentation webhook, and turns it on for ghost. The collector from #2524 stays as it is -- the webhook does not care how the collector was deployed, so there is nothing to migrate.

**Operator** -- webhook certs come from cert-manager, which is why the ks depends on it. Config lives in a second Kustomization so the `Instrumentation` CR applies after its CRD exists, same shape as cilium app/config.

**Instrumentation** -- one CR in monitoring, referenced cross-namespace as `monitoring/default`, so every app from here on is a single annotation. `parentbased_always_on` makes the app honour the sampling decision the gateway already made, so no app span outlives a dropped parent.

**ghost** -- the annotation goes through `defaultPodOptions`. Note that user values replace the chart's hardcoded pod annotations rather than merging, so `sidecar.istio.io/inject: "false"` is set explicitly here to keep it.

The operator injects an init container that copies the SDK in and sets `NODE_OPTIONS`, so ghost restarts and no image rebuild is needed. Ghost is Express on knex/mysql2, all of which auto-instrument, so this should also produce per-query spans -- the mariadb visibility a waypoint cannot give us, since it is not HTTP.

Depends on #2528 and #2529 for the mesh spans these attach to.

Verify:
```
kubectl -n monitoring get instrumentation
kubectl -n ghost get pod -o jsonpath='{.items[0].spec.initContainers[*].name}'
```
