### PR TITLE
fix(tempo): enable the local-blocks processor

### DIFF
--- a/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
@@ -31,12 +31,16 @@ spec:
       metricsGenerator:
         enabled: true
         remoteWriteUrl: http://kube-prometheus-stack-prometheus:9090/api/v1/write
+        processor:
+          local_blocks:
+            flush_to_storage: true
       overrides:
         defaults:
           metrics_generator:
             processors:
               - service-graphs
               - span-metrics
+              - local-blocks
     persistence:
       enabled: true
       size: 100Gi


### PR DESCRIPTION
Grafana Traces Drilldown fails with `localblocks processor not found`. TraceQL metrics queries are served by the `local-blocks` processor, which #2524 did not enable -- it set only `service-graphs` and `span-metrics`, which cover the service map and RED metrics but not TraceQL metrics.

Watch the naming: the processor is `local-blocks` in the overrides list and `local_blocks` in the config block. Both are needed -- listing it without configuring it leaves it on defaults, and configuring it without listing it does nothing.

`flush_to_storage: true` writes completed blocks to the trace backend so drilldown queries can reach past what the generator holds in memory. Without it you only get roughly the last few minutes.
