### PR TITLE
feat(jellyfin): auto-instrument with otel

### DIFF
--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      annotations:
+        instrumentation.opentelemetry.io/inject-dotnet: monitoring/sampled
     stateful: true
     persistence:
       config:

--- a/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
@@ -12,3 +12,18 @@ spec:
   sampler:
     type: parentbased_always_on
   nodejs: {}
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: sampled
+spec:
+  exporter:
+    endpoint: http://otel-collector-opentelemetry-collector.monitoring:4318
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.1"
+  dotnet: {}


### PR DESCRIPTION
Auto-instruments jellyfin, and adds a second `Instrumentation` for apps that generate their own traffic.

**Why a second CR.** `default` uses `parentbased_always_on`, which only inherits a decision when there is a parent. Jellyfin's background jobs and library scans start their own traces with no mesh parent, so "always on" means unconditional. `sampled` uses `parentbased_traceidratio` at 0.1 instead. Ghost stays on `default` -- it is low volume and we want every request while chasing the intermittent 404.

**What we get.** ASP.NET Core server spans, HttpClient spans for metadata lookups, and EF Core query spans -- jellyfin is EF Core on SQLite. ffmpeg is a subprocess and will not appear.

Worth watching after this lands:

- Streaming responses are long-lived, so a movie is one span open for its whole duration. Expect odd-looking traces rather than breakage.
- .NET auto-instrumentation is the CLR profiler rewriting bytecode, typically 5-15% CPU. On a transcoding box that is a real cost, unlike ghost. If it hurts, this is one annotation to remove.

`default` is not mesh-enrolled, so these spans have no gateway parent yet -- they will once the namespace is enrolled and waypointed.
