### PR TITLE
feat(home-assistant): auto-instrument with otel

### DIFF
--- a/kubernetes/apps/home-assistant/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-assistant/home-assistant/app/helmrelease.yaml
@@ -30,6 +30,8 @@ spec:
   values:
     stateful: true
     defaultPodOptions:
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: monitoring/sampled
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
@@ -27,3 +27,4 @@ spec:
     type: parentbased_traceidratio
     argument: "0.1"
   dotnet: {}
+  python: {}


### PR DESCRIPTION
Auto-instruments home-assistant. Stacked on #2532 for the `sampled` Instrumentation; adds `python` to it.

HA makes a lot of outbound calls, which is the interesting part -- aiohttp is in the auto-instrumentation bundle, so integration polling and API calls out to devices should each produce a span.

**Merge this one on its own and watch the rollout.** HA's image is Alpine, so musl, and the operator's python auto-instrumentation ships packages built against glibc. The injection works by prepending to `PYTHONPATH`, so if anything in there fails to import, HA does not start -- this is not a silent skip like a missing init container. Separate PR from jellyfin for exactly that reason.

If it fails, remove the annotation and HA comes back on the next reconcile. The fallback would be a custom image with the SDK built for musl, which is a bigger piece of work and probably not worth it for tracing alone.

Sampling is 0.1 via the shared `sampled` CR. HA polls constantly and originates its own traces with no parent, so unconditional sampling here would be a firehose.

Verify:
```
kubectl -n home-assistant rollout status deploy/home-assistant
kubectl -n home-assistant logs deploy/home-assistant --tail=50
```
