### PR TITLE
feat(default): add a waypoint

### DIFF
--- a/kubernetes/apps/default/ersatztv/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ersatztv/app/helmrelease.yaml
@@ -26,6 +26,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    service:
+      app:
+        labels:
+          istio.io/use-waypoint: none
     stateful: true
     persistence:
       config:

--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -29,6 +29,10 @@ spec:
     defaultPodOptions:
       annotations:
         instrumentation.opentelemetry.io/inject-dotnet: monitoring/sampled
+    service:
+      app:
+        labels:
+          istio.io/use-waypoint: none
     stateful: true
     persistence:
       config:

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./radarr/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./sonarr/ks.yaml
+  - ./waypoint/ks.yaml
   - ./wizarr/ks.yaml
 patches:
   - patch: |-

--- a/kubernetes/apps/default/namespace.yaml
+++ b/kubernetes/apps/default/namespace.yaml
@@ -9,3 +9,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
     pod-security.kubernetes.io/enforce: privileged
     istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint

--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -26,6 +26,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    service:
+      app:
+        labels:
+          istio.io/use-waypoint: none
     stateful: true
     defaultPodOptions:
       securityContext:

--- a/kubernetes/apps/default/waypoint/app/kustomization.yaml
+++ b/kubernetes/apps/default/waypoint/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./waypoint.yaml

--- a/kubernetes/apps/default/waypoint/app/waypoint.yaml
+++ b/kubernetes/apps/default/waypoint/app/waypoint.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE

--- a/kubernetes/apps/default/waypoint/ks.yaml
+++ b/kubernetes/apps/default/waypoint/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomization_v1beta2.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-default-waypoint
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/default/waypoint/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks: []
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Waypoints `default`. The namespace is already ambient from #2523, so this is the Gateway plus the namespace label.

This is the namespace where waypoints actually pay off -- the *arr stack, overseerr and prowlarr call each other constantly over HTTP, and today that is an opaque L4 tunnel. Those calls become spans.

**Three services opt out via `istio.io/use-waypoint: none`:** plex, jellyfin and ersatztv. They stream, and a waypoint would put a second Envoy in the path of bulk video -- their external traffic already crosses the gateway. The costs are buffering and CPU on sustained transfers, and streams dropping whenever the waypoint rolls. There is nothing to learn from an L7 span on a two-hour video response either.

Redis stays in. It only exposes service annotations, not labels, and `use-waypoint` has to be a label -- not worth `commonLabels` (which bitnami folds into selectors) to save sub-millisecond on a cache.

The waypoint gets its own Kustomization because it is namespace-scoped rather than belonging to any one app, and manifests here cannot carry an explicit `metadata.namespace` -- the verify workflow rejects it.
