### PR TITLE
fix(otel): accept b3 trace context

### DIFF
--- a/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
+++ b/kubernetes/apps/monitoring/otel-operator/config/instrumentation.yaml
@@ -9,6 +9,8 @@ spec:
   propagators:
     - tracecontext
     - baggage
+    - b3
+    - b3multi
   sampler:
     type: parentbased_always_on
   nodejs: {}
@@ -23,6 +25,8 @@ spec:
   propagators:
     - tracecontext
     - baggage
+    - b3
+    - b3multi
   sampler:
     type: parentbased_traceidratio
     argument: "0.1"


### PR DESCRIPTION
App spans are landing as roots instead of children of the gateway span, which is what a propagation format mismatch looks like.

Istio propagates B3 (`x-b3-traceid` and friends), while the OTel SDKs default to W3C `traceparent`. We only listed `tracecontext`, so if the gateway is sending B3 the SDK finds no incoming context and starts a new trace. Adding both B3 forms makes the SDK accept either -- the composite propagator tries each on extract, so listing extra formats costs nothing when they are absent.

This is the leading hypothesis rather than a confirmed diagnosis. The definitive check is what actually arrives at a backend:

```
curl -sk --resolve echo.deangalvin.dev:443:10.1.21.20 https://echo.deangalvin.dev/
```

`x-b3-*` in the echoed headers and no `traceparent` confirms it. If `traceparent` is present, this change is harmless but the cause is elsewhere -- next suspect would be the sampling flag, since an unsampled parent still produces a span but drops the link.

Pods need a restart to pick up the new propagator env.
