### PR TITLE
feat(monitoring): add openobserve

### DIFF
--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./grafana/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
+  - ./openobserve/ks.yaml
   - ./otel-collector/ks.yaml
   - ./otel-operator/ks.yaml
   - ./redfish-exporter/ks.yaml

--- a/kubernetes/apps/monitoring/openobserve/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/openobserve/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openobserve
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: openobserve
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ZO_ROOT_USER_EMAIL: "{{ .username }}"
+        ZO_ROOT_USER_PASSWORD: "{{ .password }}"
+        OPENOBSERVE_AUTH_HEADER: "Basic {{ printf \"%s:%s\" .username .password | b64enc }}"
+  dataFrom:
+    - extract:
+        key: openobserve

--- a/kubernetes/apps/monitoring/openobserve/app/httproute.yaml
+++ b/kubernetes/apps/monitoring/openobserve/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: openobserve
+spec:
+  parentRefs:
+    - name: main
+      namespace: networking
+  hostnames:
+    - openobserve.deangalvin.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: openobserve
+          port: 5080

--- a/kubernetes/apps/monitoring/openobserve/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/openobserve/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./statefulset.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/monitoring/openobserve/app/statefulset.yaml
+++ b/kubernetes/apps/monitoring/openobserve/app/statefulset.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openobserve
+spec:
+  selector:
+    app: openobserve
+  ports:
+    - name: http
+      port: 5080
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openobserve
+  labels:
+    name: openobserve
+spec:
+  serviceName: openobserve
+  replicas: 1
+  selector:
+    matchLabels:
+      name: openobserve
+      app: openobserve
+  template:
+    metadata:
+      labels:
+        name: openobserve
+        app: openobserve
+    spec:
+      securityContext:
+        fsGroup: 2000
+        runAsUser: 10000
+        runAsGroup: 3000
+        runAsNonRoot: true
+      containers:
+        - name: openobserve
+          image: o2cr.ai/openobserve/openobserve:v0.91.5
+          env:
+            - name: ZO_DATA_DIR
+              value: /data
+          envFrom:
+            - secretRef:
+                name: openobserve
+          resources:
+            requests:
+              cpu: 256m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          ports:
+            - containerPort: 5080
+              name: http
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: ceph-rbd
+        resources:
+          requests:
+            storage: 50Gi

--- a/kubernetes/apps/monitoring/openobserve/ks.yaml
+++ b/kubernetes/apps/monitoring/openobserve/ks.yaml
@@ -3,14 +3,12 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cluster-apps-vector
+  name: cluster-apps-openobserve
   namespace: flux-system
 spec:
   dependsOn:
-    - name: cluster-apps-eck-operator
-    - name: cluster-apps-openobserve
     - name: cluster-apps-rook-ceph-cluster
-  path: ./kubernetes/apps/monitoring/vector/app
+  path: ./kubernetes/apps/monitoring/openobserve/app
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/monitoring/otel-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/otel-collector/app/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
     presets:
       kubernetesAttributes:
         enabled: true
+    extraEnvsFrom:
+      - secretRef:
+          name: openobserve
     ports:
       jaeger-compact:
         enabled: false
@@ -45,6 +48,11 @@ spec:
           endpoint: tempo:4317
           tls:
             insecure: true
+        otlphttp/openobserve:
+          endpoint: http://openobserve:5080/api/default
+          headers:
+            Authorization: $${env:OPENOBSERVE_AUTH_HEADER}
+            stream-name: default
       processors:
         batch:
           timeout: 5s
@@ -56,7 +64,7 @@ spec:
           traces:
             receivers: [otlp]
             processors: [batch]
-            exporters: [otlp]
+            exporters: [otlp, otlphttp/openobserve]
     resources:
       requests:
         cpu: 50m

--- a/kubernetes/apps/monitoring/otel-collector/ks.yaml
+++ b/kubernetes/apps/monitoring/otel-collector/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: cluster-apps-otel-collector
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: cluster-apps-openobserve
   path: ./kubernetes/apps/monitoring/otel-collector/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/monitoring/vector/app/config/vector.yaml
+++ b/kubernetes/apps/monitoring/vector/app/config/vector.yaml
@@ -14,6 +14,20 @@ sinks:
     inputs:
       - internal_metrics
     address: "0.0.0.0:9001"
+  openobserve:
+    type: http
+    inputs:
+      - final
+    uri: "http://openobserve.monitoring.svc.cluster.local:5080/api/default/kubernetes/_json"
+    method: post
+    auth:
+      strategy: basic
+      user: "${ZO_ROOT_USER_EMAIL}"
+      password: "${ZO_ROOT_USER_PASSWORD}"
+    compression: gzip
+    encoding:
+      codec: json
+      timestamp_format: rfc3339
   loki:
     remove_label_fields: true
     encoding:

--- a/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
@@ -46,6 +46,9 @@ spec:
         mountPath: /etc/vector/transforms
     existingConfigMaps:
       - vector-config
+    envFrom:
+      - secretRef:
+          name: openobserve
     args:
       - --config-dir
       - "/etc/vector/"


### PR DESCRIPTION
Adds an OpenObserve statefulset (ceph-rbd PVC, root creds from 1Password) behind `openobserve.deangalvin.dev`, and fans out to it from vector (logs) and otel-collector (traces) in addition to loki/tempo.

Requires a 1Password item `openobserve` with `username` + `password`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFhKSR9hDuXvo1u6iVdXAt