### PR TITLE
feat(openobserve): store parquet in ceph s3, raise memory

### DIFF
--- a/kubernetes/apps/monitoring/openobserve/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/openobserve/app/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./objectbucketclaim.yaml
   - ./statefulset.yaml
   - ./httproute.yaml

--- a/kubernetes/apps/monitoring/openobserve/app/objectbucketclaim.yaml
+++ b/kubernetes/apps/monitoring/openobserve/app/objectbucketclaim.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketClaim
+metadata:
+  name: openobserve
+spec:
+  bucketClassName: ceph
+  protocols:
+    - s3
+---
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketAccess
+metadata:
+  name: openobserve
+spec:
+  bucketClaimName: openobserve
+  bucketAccessClassName: ceph
+  credentialsSecretName: openobserve-bucket-credentials
+  protocol: s3

--- a/kubernetes/apps/monitoring/openobserve/app/statefulset.yaml
+++ b/kubernetes/apps/monitoring/openobserve/app/statefulset.yaml
@@ -35,27 +35,92 @@ spec:
         runAsUser: 10000
         runAsGroup: 3000
         runAsNonRoot: true
+      initContainers:
+        - name: credential-fetcher
+          image: ghcr.io/home-operations/k8s-sidecar:2.10.0
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              jq -r '
+                "ZO_S3_BUCKET_NAME=\(.spec.bucketName)",
+                "ZO_S3_SERVER_URL=\(.spec.secretS3.endpoint)",
+                "ZO_S3_ACCESS_KEY=\(.spec.secretS3.accessKeyID)",
+                "ZO_S3_SECRET_KEY=\(.spec.secretS3.accessSecretKey)"
+              ' /s3-secret/BucketInfo > /s3/config.env
+          volumeMounts:
+            - name: credential-fetcher
+              mountPath: /s3
+            - name: s3-credentials
+              mountPath: /s3-secret
+              readOnly: true
       containers:
         - name: openobserve
           image: o2cr.ai/openobserve/openobserve:v0.91.5
           env:
             - name: ZO_DATA_DIR
               value: /data
+            - name: ZO_LOCAL_MODE_STORAGE
+              value: s3
+            - name: ZO_S3_PROVIDER
+              value: s3
+            - name: ZO_S3_REGION_NAME
+              value: us-east-1
+            - name: ZO_MEM_TABLE_MAX_SIZE
+              value: "4096"
+            - name: ZO_MAX_FILE_SIZE_IN_MEMORY
+              value: "128"
+            - name: ZO_MEM_PERSIST_INTERVAL
+              value: "3"
+            - name: ZO_S3_BUCKET_NAME
+              valueFrom:
+                fileKeyRef:
+                  path: config.env
+                  volumeName: credential-fetcher
+                  key: ZO_S3_BUCKET_NAME
+                  optional: false
+            - name: ZO_S3_SERVER_URL
+              valueFrom:
+                fileKeyRef:
+                  path: config.env
+                  volumeName: credential-fetcher
+                  key: ZO_S3_SERVER_URL
+                  optional: false
+            - name: ZO_S3_ACCESS_KEY
+              valueFrom:
+                fileKeyRef:
+                  path: config.env
+                  volumeName: credential-fetcher
+                  key: ZO_S3_ACCESS_KEY
+                  optional: false
+            - name: ZO_S3_SECRET_KEY
+              valueFrom:
+                fileKeyRef:
+                  path: config.env
+                  volumeName: credential-fetcher
+                  key: ZO_S3_SECRET_KEY
+                  optional: false
           envFrom:
             - secretRef:
                 name: openobserve
           resources:
             requests:
-              cpu: 256m
-              memory: 512Mi
+              cpu: 500m
+              memory: 4Gi
             limits:
-              memory: 2Gi
+              memory: 12Gi
           ports:
             - containerPort: 5080
               name: http
           volumeMounts:
             - name: data
               mountPath: /data
+      volumes:
+        - name: credential-fetcher
+          emptyDir: {}
+        - name: s3-credentials
+          secret:
+            secretName: openobserve-bucket-credentials
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
Ingestion was 503ing with `MemoryTableOverflowError`; the pod had already been OOMKilled at its 2Gi limit on a 94GB node.

- Memory 2Gi → 12Gi, with `ZO_MEM_TABLE_MAX_SIZE` set explicitly rather than inherited from the 50%-of-detected-memory default.
- Parquet moves to a COSI-provisioned RGW bucket (`ZO_LOCAL_MODE_STORAGE=s3`), so retention is no longer capped by the PVC. The 50Gi volume stays for the WAL.
- Credentials unpacked from COSI's `BucketInfo` blob via initContainer + `fileKeyRef`, same as loki.

Stays single-node — sqlite metadata, no postgres.

Existing parquet on the PVC does not migrate, so history restarts at rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TTTcnSax3zfAUWvuavTgK
